### PR TITLE
Map body field as keyword in addition to text

### DIFF
--- a/schema/observability/logs/aws_alb.mapping
+++ b/schema/observability/logs/aws_alb.mapping
@@ -118,7 +118,13 @@
               "type": "keyword"
             },
             "redirect_url": {
-              "type": "keyword"
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
             },
             "error": {
               "properties": {

--- a/schema/observability/logs/http.mapping
+++ b/schema/observability/logs/http.mapping
@@ -37,8 +37,13 @@
               "ignore_above": 2048
             },
             "url": {
-              "type": "keyword",
-              "ignore_above": 2048
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
             },
             "schema": {
               "type": "keyword",

--- a/schema/observability/logs/logs.mapping
+++ b/schema/observability/logs/logs.mapping
@@ -91,7 +91,13 @@
           }
         },
         "body": {
-          "type": "text"
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 256
+            }
+          }
         },
         "@message": {
           "type": "alias",


### PR DESCRIPTION
### Description
In the current log and http template mappings. There are fields related to body of logs and request/response of http requests which are mapped as field type text. It would be faster to query these fields, if they are mapped as keyword.

### Issues Resolved
https://github.com/opensearch-project/opensearch-catalog/issues/16

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
