### PR TITLE
add dictionary fields set info for each index & component templates

### DIFF
--- a/docs/schema/observability/logs/aws_alb.md
+++ b/docs/schema/observability/logs/aws_alb.md
@@ -1,0 +1,36 @@
+# Observability Category: Alb Log Fields
+
+AWS Application Load Balancer (ALB) logs contain information that provides insights into the traffic patterns, application behavior, and operational performance of the load balancer.
+
+## Field Names and Types
+
+| Field Name              | Type    | Description                             |
+|-------------------------|---------|-----------------------------------------|
+| `aws.alb.name`           | keyword | The name of the ALB.                    |
+| `aws.alb.type`           | keyword | The type of the ALB.                    |
+| `aws.alb.target_group.arn`| keyword | The ARN of the target group.             |
+| `aws.alb.listener`       | keyword | The listener of the ALB.                |
+| `aws.alb.protocol`       | keyword | The protocol of the ALB.                |
+| `aws.alb.request_processing_time.sec` | float | The request processing time in seconds.   |
+| `aws.alb.backend_processing_time.sec` | float | The backend processing time in seconds.   |
+| `aws.alb.response_processing_time.sec` | float | The response processing time in seconds. |
+| `aws.alb.connection_time.ms` | long  | The connection time in milliseconds.     |
+| `aws.alb.tls_handshake_time.ms` | long | The TLS handshake time in milliseconds. |
+| `aws.alb.backend.ip`     | keyword | The IP address of the backend.          |
+| `aws.alb.backend.port`    | keyword | The port of the backend.                |
+| `aws.alb.backend.http.response.status_code` | long | The HTTP response status code of the backend. |
+| `aws.alb.ssl_cipher`      | keyword | The SSL cipher used.                    |
+| `aws.alb.ssl_protocol`    | keyword | The SSL protocol used.                  |
+| `aws.alb.chosen_cert.arn` | keyword | The ARN of the chosen certificate.       |
+| `aws.alb.chosen_cert.serial` | keyword | The serial number of the chosen certificate. |
+| `aws.alb.incoming_tls_alert` | keyword | The incoming TLS alert.                 |
+| `aws.alb.tls_named_group` | keyword | The named TLS group.                    |
+| `aws.alb.trace_id`        | keyword | The trace ID.                           |
+| `aws.alb.matched_rule_priority` | keyword | The priority of the matched rule. |
+| `aws.alb.action_executed` | keyword | The executed action.                    |
+| `aws.alb.redirect_url`    | keyword | The redirect URL.                       |
+| `aws.alb.error.reason `   | keyword | The reason for the error.               |
+| `aws.alb.target_port `    | keyword | The target port.                        |
+| `aws.alb.target_status_code `| keyword | The target status code.                 |
+| `aws.alb.classification`  | keyword | The classification.                     |
+| `aws.alb.classification_reason` | keyword | The reason for the classification. |

--- a/docs/schema/observability/logs/aws_elb.md
+++ b/docs/schema/observability/logs/aws_elb.md
@@ -1,0 +1,31 @@
+# Observability Category: Elb Log Fields
+
+AWS Elastic Load Balancer (ELB) logs contain information that provides insights into the traffic patterns, application behavior, and operational performance of the load balancer. The aws.elb fields capture a range of data points from these logs.
+
+## Field Names and Types
+
+| Field Name                         | Type         | Description |
+|------------------------------------|--------------|-------------|
+| `aws.elb.backend.ip`               | ip           | Backend IP address of the request |
+| `aws.elb.backend.port`             | integer      | Backend port of the request |
+| `aws.elb.backend.processing_time`  | half_float   | Processing time on the backend |
+| `aws.elb.backend.status_code`      | short        | Status code returned from the backend |
+| `aws.elb.client.ip`                | ip           | Client's IP address |
+| `aws.elb.client.port`              | integer      | Client's port |
+| `aws.elb.connection_time`          | integer      | Connection time |
+| `aws.elb.destination.ip`           | ip           | Destination IP address of the request |
+| `aws.elb.destination.port`         | integer      | Destination port of the request |
+| `aws.elb.elb_status_code`          | short        | Status code returned by the ELB |
+| `aws.elb.http.port`                | integer      | Port for the HTTP request |
+| `aws.elb.http.version`             | keyword      | HTTP version used |
+| `aws.elb.matched_rule_priority`    | integer      | Priority of the rule matched |
+| `aws.elb.received_bytes`           | integer      | Bytes received |
+| `aws.elb.request_creation_time`    | date         | Request creation time |
+| `aws.elb.request_processing_time`  | half_float   | Time spent processing the request |
+| `aws.elb.response_processing_time` | half_float   | Time spent processing the response |
+| `aws.elb.sent_bytes`               | integer      | Bytes sent |
+| `aws.elb.target_ip`                | ip           | Target IP address for the request |
+| `aws.elb.target_port`              | integer      | Target port for the request |
+| `aws.elb.target_processing_time`   | half_float   | Processing time at the target |
+| `aws.elb.target_status_code`       | short        | Status code returned by the target |
+| `aws.elb.timestamp`                | date         | Timestamp of the event |

--- a/docs/schema/observability/metrics/metrics.md
+++ b/docs/schema/observability/metrics/metrics.md
@@ -1,0 +1,57 @@
+# Observability Category: Metrics Fields
+
+The metrics protocol hold all the information used to build the summary / aggregation of the time-series data points in a form that will allow several types of summation information to be accessible.
+For additional info [see](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#model-details) 
+
+## Field Names and Types
+
+
+| Field Name       | Type      | Description |
+| ---------------- | --------- | ----------- |
+| name | text/keyword | The name of the metric. |
+| attributes.data_stream.dataset | keyword | Identifies the data set. |
+| attributes.data_stream.namespace | keyword | Specifies the namespace of the data stream. |
+| attributes.data_stream.type | keyword | Specifies the type of data in the stream. |
+| description | text/keyword | Description of the metric. |
+| unit | keyword | The unit of the metric, e.g., bytes, seconds, etc. |
+| kind | keyword | The kind of metric (e.g., gauge, counter, histogram, etc.). |
+| aggregationTemporality | keyword | Specifies the temporality of the aggregation (e.g., cumulative, delta). |
+| monotonic | boolean | Indicates if the value can only increase. |
+| startTime | date | The start time of the metric collection. |
+| @timestamp | date | The timestamp when the metric was collected or received. |
+| observedTimestamp | date_nanos | The precise timestamp of when the metric was observed. |
+| value.int | integer | Integer value of the metric. |
+| value.double | double | Double/float value of the metric. |
+| buckets.count | long | Count of the observed values in the bucket (used in histogram metrics). |
+| buckets.sum | double | Sum of the observed values in the bucket (used in histogram metrics). |
+| buckets.max | float | Maximum observed value in the bucket (used in histogram metrics). |
+| buckets.min | float | Minimum observed value in the bucket (used in histogram metrics). |
+| bucketCount | long | The total number of buckets. |
+| bucketCountsList | long | A list of counts for multiple buckets. |
+| explicitBoundsList | float | A list of explicit bounds for histogram metrics. |
+| explicitBoundsCount | float | Count of explicit bounds. |
+| quantiles.quantile | double | The quantile value (e.g., 0.95 for 95th percentile). |
+| quantiles.value | double | The value at the specified quantile. |
+| quantileValuesCount | long | Count of quantile values. |
+| positiveBuckets.count | long | Count of positive observed values in the bucket (used in histogram metrics). |
+| positiveBuckets.max | float | Maximum of positive observed values in the bucket (used in histogram metrics). |
+| positiveBuckets.min | float | Minimum of positive observed values in the bucket (used in histogram metrics). |
+| negativeBuckets.count | long | Count of negative observed values in the bucket (used in histogram metrics). |
+| negativeBuckets.max | float | Maximum of negative observed values in the bucket (used in histogram metrics). |
+| negativeBuckets.min | float | Minimum of negative observed values in the bucket (used in histogram metrics). |
+| negativeOffset | integer | Offset for the negative buckets in a histogram. |
+| positiveOffset | integer | Offset for the positive buckets in a histogram. |
+| zeroCount | long | Count of observed values that are zero. |
+| scale | long | The scale factor for the observed values. |
+| max | float | Maximum value of the observed metric. |
+| min | float | Minimum value of the observed metric. |
+| sum | float | Sum of the observed metric values. |
+| count | long | Total count of the observed values. |
+| exemplar.time | date | The timestamp of the exemplar (an example point that represents the distribution). |
+| exemplar.traceId | keyword | Trace ID linked with the exemplar (useful for correlation between metrics and traces). |
+| exemplar.spanId | keyword | Span ID linked with the exemplar (useful for correlation between metrics and traces). |
+| instrumentationScope.name | text/keyword | Name of the instrumentation scope. |
+| instrumentationScope.version | text/keyword | Version of the instrumentation scope. |
+| instrumentationScope.droppedAttributesCount | integer | Count of attributes that were dropped due to exceeding the limit. |
+| instrumentationScope.schemaUrl | text/keyword | URL of the schema used for the instrumentation scope. |
+| schemaUrl | text/keyword | URL of the schema used for this metric. |

--- a/docs/schema/observability/traces/services.md
+++ b/docs/schema/observability/traces/services.md
@@ -1,0 +1,15 @@
+# Observability Category: Services Fields
+
+
+## Field Names and Types
+
+| Field Name             | Type    | Description                                  |
+|------------------------|---------|----------------------------------------------|
+| destination.domain     | keyword | The domain of the destination.                |
+| destination.resource   | keyword | The resource of the destination.              |
+| hashId                 | keyword | The hash ID for the service.                  |
+| serviceName            | keyword | The name of the service.                      |
+| kind                   | keyword | The kind of the service.                      |
+| target.domain          | keyword | The domain of the target.                     |
+| target.resource        | keyword | The resource of the target.                   |
+| traceGroupName         | keyword | The trace group name associated with the service.   |

--- a/docs/schema/observability/traces/tracegroups.md
+++ b/docs/schema/observability/traces/tracegroups.md
@@ -1,0 +1,11 @@
+# Observability Category: TraceGroup Fields
+
+
+## Field Names and Types
+
+| Field Name             | Type    | Description                  |
+|------------------------|---------|------------------------------|
+| traceGroup     | keyword | The trace group name.        |
+| traceGroupFields.endTime   | long    | The trace group end time.    |
+| traceGroupFields.durationInNanos                   | long    | The trace group  duration.   |
+| traceGroupFields.statusCode                  | integer | The trace group status code. |

--- a/docs/schema/observability/traces/traces.md
+++ b/docs/schema/observability/traces/traces.md
@@ -1,0 +1,34 @@
+# Observability Category: Trace Fields
+
+
+## Field Names and Types
+
+
+| Field Name                | Type         | Description                        |
+|---------------------------|--------------|------------------------------------|
+| traceId                   | keyword      | The trace ID.                      |
+| spanId                    | keyword      | The span ID.                       |
+| traceState                | text         | The trace state.                   |
+| parentSpanId              | keyword      | The parent span ID.                |
+| name                      | keyword      | The name of the trace.             |
+| kind                      | keyword      | The kind of the trace.             |
+| startTime                 | date_nanos   | The start time of the trace.       |
+| endTime                   | date_nanos   | The end time of the trace.         |
+| droppedAttributesCount    | long         | The count of dropped attributes.   |
+| droppedEventsCount        | long         | The count of dropped events.       |
+| droppedLinksCount         | long         | The count of dropped links.        |
+| status.code               | long         | The status code of the trace.      |
+| status.message            | keyword      | The status message of the trace.   |
+| attributes.serviceName    | keyword      | The name of the service.           |
+| attributes.data_stream    | object       | Data stream attributes.            |
+| events.name               | keyword      | The name of the event.             |
+| events.@timestamp         | date_nanos   | The timestamp of the event.        |
+| events.observedTimestamp  | date_nanos   | The observed timestamp of the event.|
+| links.traceId             | keyword      | The trace ID of the link.          |
+| links.spanId              | keyword      | The span ID of the link.           |
+| links.traceState          | text         | The trace state of the link.       |
+| instrumentationScope.name | keyword      | The name of the instrumentation scope.  |
+| instrumentationScope.version | keyword   | The version of the instrumentation scope.  |
+| instrumentationScope.droppedAttributesCount | integer | The count of dropped attributes in the instrumentation scope. |
+| instrumentationScope.schemaUrl | keyword  | The URL of the schema for the instrumentation scope.   |
+| schemaUrl                 | keyword      | The URL of the schema.             |

--- a/docs/schema/system/dictionary.schema
+++ b/docs/schema/system/dictionary.schema
@@ -38,6 +38,9 @@
             },
             "object_type": {
               "type": "string"
+            },
+            "correlation_field": {
+              "type": "string"
             }
           },
           "required": ["category", "component", "caption", "description", "examples", "object_name", "object_type"]

--- a/schema/observability/logs/aws_alb.dictionary
+++ b/schema/observability/logs/aws_alb.dictionary
@@ -1,0 +1,370 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "aws.alb.name": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "ALB Name",
+        "description": "The name of the ALB.",
+        "examples": [
+          "my-alb"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.type": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "ALB Type",
+        "description": "The type of the ALB.",
+        "examples": [
+          "application"
+        ],
+        "object_name": "type",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.target_group.arn": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Target Group ARN",
+        "description": "The ARN of the target group.",
+        "examples": [
+          "arn:aws:elasticloadbalancing:us-west-2:123456789012:targetgroup/my-target-group/1234567890abcdef"
+        ],
+        "object_name": "target_group.arn",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.listener": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "ALB Listener",
+        "description": "The listener of the ALB.",
+        "examples": [
+          "arn:aws:elasticloadbalancing:us-west-2:123456789012:listener/app/my-load-balancer/1234567890abcdef"
+        ],
+        "object_name": "listener",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.protocol": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "ALB Protocol",
+        "description": "The protocol of the ALB.",
+        "examples": [
+          "HTTP"
+        ],
+        "object_name": "protocol",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.request_processing_time.sec": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Request Processing Time",
+        "description": "The request processing time in seconds.",
+        "examples": [
+          0.043
+        ],
+        "object_name": "request_processing_time.sec",
+        "object_type": "float"
+      }
+    },
+    {
+      "aws.alb.backend_processing_time.sec": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Backend Processing Time",
+        "description": "The backend processing time in seconds.",
+        "examples": [
+          0.021
+        ],
+        "object_name": "backend_processing_time.sec",
+        "object_type": "float"
+      }
+    },
+    {
+      "aws.alb.response_processing_time.sec": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Response Processing Time",
+        "description": "The response processing time in seconds.",
+        "examples": [
+          0.019
+        ],
+        "object_name": "response_processing_time.sec",
+        "object_type": "float"
+      }
+    },
+    {
+      "aws.alb.connection_time.ms": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Connection Time",
+        "description": "The connection time in milliseconds.",
+        "examples": [
+          47
+        ],
+        "object_name": "connection_time.ms",
+        "object_type": "long"
+      }
+    },
+    {
+      "aws.alb.tls_handshake_time.ms": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "TLS Handshake Time",
+        "description": "The TLS handshake time in milliseconds.",
+        "examples": [
+          83
+        ],
+        "object_name": "tls_handshake_time.ms",
+        "object_type": "long"
+      }
+    },
+    {
+      "aws.alb.backend.ip": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Backend IP",
+        "description": "The IP address of the backend server.",
+        "examples": [
+          "192.0.2.10"
+        ],
+        "object_name": "backend.ip",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.backend.port": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Backend Port",
+        "description": "The port of the backend server.",
+        "examples": [
+          "80"
+        ],
+        "object_name": "backend.port",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.backend.http.response.status_code": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Backend HTTP Response Status Code",
+        "description": "The HTTP response status code from the backend server.",
+        "examples": [
+          200
+        ],
+        "object_name": "backend.http.response.status_code",
+        "object_type": "long"
+      }
+    },
+    {
+      "aws.alb.ssl_cipher": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "SSL Cipher",
+        "description": "The SSL cipher used in the connection.",
+        "examples": [
+          "AES256-SHA"
+        ],
+        "object_name": "ssl_cipher",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.ssl_protocol": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "SSL Protocol",
+        "description": "The SSL protocol used in the connection.",
+        "examples": [
+          "TLSv1.2"
+        ],
+        "object_name": "ssl_protocol",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.chosen_cert.arn": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Chosen Certificate ARN",
+        "description": "The ARN of the chosen SSL certificate.",
+        "examples": [
+          "arn:aws:acm:us-west-2:123456789012:certificate/12345678-1234-1234-1234-123456789012"
+        ],
+        "object_name": "chosen_cert.arn",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.chosen_cert.serial": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Chosen Certificate Serial",
+        "description": "The serial number of the chosen SSL certificate.",
+        "examples": [
+          "0123456789ABCDEF"
+        ],
+        "object_name": "chosen_cert.serial",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.incoming_tls_alert": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Incoming TLS Alert",
+        "description": "The incoming TLS alert.",
+        "examples": [
+          "unknown"
+        ],
+        "object_name": "incoming_tls_alert",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.tls_named_group": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "TLS Named Group",
+        "description": "The TLS named group.",
+        "examples": [
+          "secp256r1"
+        ],
+        "object_name": "tls_named_group",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.trace_id": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Trace ID",
+        "description": "The ID of the trace.",
+        "examples": [
+          "d799ffbe8c8b6c49"
+        ],
+        "object_name": "trace_id",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.matched_rule_priority": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Matched Rule Priority",
+        "description": "The priority of the matched rule.",
+        "examples": [
+          "10"
+        ],
+        "object_name": "matched_rule_priority",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.action_executed": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Action Executed",
+        "description": "The action executed.",
+        "examples": [
+          "forward"
+        ],
+        "object_name": "action_executed",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.redirect_url": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Redirect URL",
+        "description": "The redirect URL.",
+        "examples": [
+          "https://example.com"
+        ],
+        "object_name": "redirect_url",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.error.reason": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Error Reason",
+        "description": "The reason for the error.",
+        "examples": [
+          "Timeout"
+        ],
+        "object_name": "error.reason",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.target_port": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Target Port",
+        "description": "The port of the target.",
+        "examples": [
+          "8080"
+        ],
+        "object_name": "target_port",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.target_status_code": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Target Status Code",
+        "description": "The status code from the target.",
+        "examples": [
+          "200"
+        ],
+        "object_name": "target_status_code",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.classification": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Classification",
+        "description": "The classification of the log event.",
+        "examples": [
+          "success"
+        ],
+        "object_name": "classification",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "aws.alb.classification_reason": {
+        "category": "aws_alb",
+        "component": "alb",
+        "caption": "Classification Reason",
+        "description": "The reason for the classification.",
+        "examples": [
+          "Valid"
+        ],
+        "object_name": "classification_reason",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/logs/aws_alb.mapping
+++ b/schema/observability/logs/aws_alb.mapping
@@ -9,7 +9,7 @@
       },
       "aws": {
         "type": "object",
-        "elb": {
+        "alb": {
           "properties": {
             "name": {
               "type": "keyword"

--- a/schema/observability/logs/aws_elb.dictionary
+++ b/schema/observability/logs/aws_elb.dictionary
@@ -1,0 +1,217 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "aws.elb.backend.ip": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Backend IP",
+        "description": "Backend IP address of the request",
+        "examples": [],
+        "object_name": "backend.ip",
+        "object_type": "ip"
+      },
+      "aws.elb.backend.port": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Backend Port",
+        "description": "Backend port of the request",
+        "examples": [],
+        "object_name": "backend.port",
+        "object_type": "integer"
+      },
+      "aws.elb.backend.processing_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Backend Processing Time",
+        "description": "Processing time on the backend",
+        "examples": [],
+        "object_name": "backend.processing_time",
+        "object_type": "half_float"
+      },
+      "aws.elb.backend.status_code": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Backend Status Code",
+        "description": "Status code returned from the backend",
+        "examples": [],
+        "object_name": "backend.status_code",
+        "object_type": "short"
+      },
+      "aws.elb.client.ip": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Client IP",
+        "description": "Client's IP address",
+        "examples": [],
+        "object_name": "client.ip",
+        "object_type": "ip"
+      },
+      "aws.elb.client.port": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Client Port",
+        "description": "Client's port",
+        "examples": [],
+        "object_name": "client.port",
+        "object_type": "integer"
+      },
+      "aws.elb.connection_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Connection Time",
+        "description": "Connection time",
+        "examples": [],
+        "object_name": "connection_time",
+        "object_type": "integer"
+      },
+      "aws.elb.destination.ip": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Destination IP",
+        "description": "Destination IP address of the request",
+        "examples": [],
+        "object_name": "destination.ip",
+        "object_type": "ip"
+      },
+      "aws.elb.destination.port": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Destination Port",
+        "description": "Destination port of the request",
+        "examples": [],
+        "object_name": "destination.port",
+        "object_type": "integer"
+      },
+      "aws.elb.elb_status_code": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "ELB Status Code",
+        "description": "Status code returned by the ELB",
+        "examples": [],
+        "object_name": "elb_status_code",
+        "object_type": "short"
+      }
+    },
+    {
+      "aws.elb.http.port": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "HTTP Port",
+        "description": "The port of the HTTP request",
+        "examples": [],
+        "object_name": "http.port",
+        "object_type": "integer"
+      },
+      "aws.elb.http.version": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "HTTP Version",
+        "description": "The HTTP version of the request",
+        "examples": [],
+        "object_name": "http.version",
+        "object_type": "keyword"
+      },
+      "aws.elb.matched_rule_priority": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Matched Rule Priority",
+        "description": "The priority of the rule that was matched",
+        "examples": [],
+        "object_name": "matched_rule_priority",
+        "object_type": "integer"
+      },
+      "aws.elb.received_bytes": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Received Bytes",
+        "description": "The number of bytes received",
+        "examples": [],
+        "object_name": "received_bytes",
+        "object_type": "integer"
+      },
+      "aws.elb.request_creation_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Request Creation Time",
+        "description": "The timestamp when the request was created",
+        "examples": [],
+        "object_name": "request_creation_time",
+        "object_type": "date"
+      },
+      "aws.elb.request_processing_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Request Processing Time",
+        "description": "The time taken to process the request",
+        "examples": [],
+        "object_name": "request_processing_time",
+        "object_type": "half_float"
+      },
+      "aws.elb.response_processing_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Response Processing Time",
+        "description": "The time taken to process the response",
+        "examples": [],
+        "object_name": "response_processing_time",
+        "object_type": "half_float"
+      },
+      "aws.elb.sent_bytes": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Sent Bytes",
+        "description": "The number of bytes sent",
+        "examples": [],
+        "object_name": "sent_bytes",
+        "object_type": "integer"
+      },
+      "aws.elb.target_ip": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Target IP",
+        "description": "The target IP address of the request",
+        "examples": [],
+        "object_name": "target_ip",
+        "object_type": "ip"
+      },
+      "aws.elb.target_port": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Target Port",
+        "description": "The target port of the request",
+        "examples": [],
+        "object_name": "target_port",
+        "object_type": "integer"
+      },
+      "aws.elb.target_processing_time": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Target Processing Time",
+        "description": "The time taken to process the request by the target",
+        "examples": [],
+        "object_name": "target_processing_time",
+        "object_type": "half_float"
+      },
+      "aws.elb.target_status_code": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Target Status Code",
+        "description": "The status code returned by the target",
+        "examples": [],
+        "object_name": "target_status_code",
+        "object_type": "short"
+      },
+      "aws.elb.timestamp": {
+        "category": "aws_elb",
+        "component": "elb",
+        "caption": "Timestamp",
+        "description": "The timestamp of the log event",
+        "examples": [],
+        "object_name": "timestamp",
+        "object_type": "date"
+      }
+    }
+  ]
+}

--- a/schema/observability/logs/cloud.dictionary
+++ b/schema/observability/logs/cloud.dictionary
@@ -1,0 +1,151 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "cloud.provider": {
+        "category": "cloud",
+        "component": "provider",
+        "caption": "cloud provider",
+        "description": "The cloud service provider (e.g., AWS, GCP, Azure).",
+        "examples": [
+          "AWS",
+          "GCP",
+          "Azure"
+        ],
+        "object_name": "provider",
+        "object_type": "keyword"
+      },
+      "cloud.availability_zone": {
+        "category": "cloud",
+        "component": "availability",
+        "caption": "availability zone",
+        "description": "The availability zone of the cloud resource within the provider's infrastructure.",
+        "examples": [
+          "us-east-1a",
+          "us-west-2b",
+          "europe-west1-c"
+        ],
+        "object_name": "availability_zone",
+        "object_type": "keyword"
+      },
+      "cloud.region": {
+        "category": "cloud",
+        "component": "region",
+        "caption": "cloud region",
+        "description": "The region of the cloud resource within the provider's infrastructure.",
+        "examples": [
+          "us-east-1",
+          "us-west-2",
+          "europe-west1"
+        ],
+        "object_name": "region",
+        "object_type": "keyword"
+      },
+      "cloud.machine.type": {
+        "category": "cloud",
+        "component": "machine",
+        "caption": "machine type",
+        "description": "The type of virtual machine or compute resource used (e.g., t2.micro, n1-standard-1).",
+        "examples": [
+          "t2.micro",
+          "n1-standard-1",
+          "Standard_A1"
+        ],
+        "object_name": "type",
+        "object_type": "keyword"
+      },
+      "cloud.account.id": {
+        "category": "cloud",
+        "component": "account",
+        "caption": "account id",
+        "description": "The unique identifier of the cloud account.",
+        "examples": [
+          "123456789012",
+          "210987654321",
+          "019283746565"
+        ],
+        "object_name": "id",
+        "object_type": "keyword"
+      },
+      "cloud.account.name": {
+        "category": "cloud",
+        "component": "account",
+        "caption": "account name",
+        "description": "The name of the cloud account.",
+        "examples": [
+          "production-account",
+          "test-account",
+          "development-account"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "cloud.service.name": {
+        "category": "cloud",
+        "component": "service",
+        "caption": "service name",
+        "description": "The name of the cloud service (e.g., EC2, S3, Compute Engine).",
+        "examples": [
+          "EC2",
+          "S3",
+          "Compute Engine"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "cloud.project.id": {
+        "category": "cloud",
+        "component": "project",
+        "caption": "project id",
+        "description": "The unique identifier of the cloud project.",
+        "examples": [
+          "my-cloud-project-123",
+          "another-cloud-project-456",
+          "yet-another-cloud-project-789"
+        ],
+        "object_name": "id",
+        "object_type": "keyword"
+      },
+      "cloud.project.name": {
+        "category": "cloud",
+        "component": "project",
+        "caption": "project name",
+        "description": "The name of the cloud project.",
+        "examples": [
+          "My Cloud Project",
+          "Another Cloud Project",
+          "Yet Another Cloud Project"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "cloud.instance.id": {
+        "category": "cloud",
+        "component": "instance",
+        "caption": "instance id",
+        "description": "The unique identifier of the cloud instance or virtual machine.",
+        "examples": [
+          "i-0abcd1234efgh5678",
+          "i-0fgh5678abcd1234",
+          "i-01234efgh5678abcd"
+        ],
+        "object_name": "id",
+        "object_type": "keyword"
+      },
+      "cloud.instance.name": {
+        "category": "cloud",
+        "component": "instance",
+        "caption": "instance name",
+        "description": "The name of the cloud instance or virtual machine.",
+        "examples": [
+          "web-server-instance",
+          "database-server-instance",
+          "application-server-instance"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/logs/communication.dictionary
+++ b/schema/observability/logs/communication.dictionary
@@ -1,0 +1,196 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "communication.sock.family": {
+        "category": "communication",
+        "component": "socket",
+        "caption": "socket family",
+        "description": "The socket family of the communication event (e.g., AF_INET, AF_INET6).",
+        "examples": [
+          "AF_INET",
+          "AF_INET6"
+        ],
+        "object_name": "family",
+        "object_type": "keyword"
+      },
+      "communication.source.address": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source address",
+        "description": "The source address of the communication event.",
+        "examples": [
+          "192.0.2.0",
+          "2001:db8::"
+        ],
+        "object_name": "address",
+        "object_type": "text"
+      },
+      "communication.source.domain": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source domain",
+        "description": "The source domain of the communication event.",
+        "examples": [
+          "example.com",
+          "another-example.com"
+        ],
+        "object_name": "domain",
+        "object_type": "text"
+      },
+      "communication.source.bytes": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source bytes",
+        "description": "The number of bytes sent by the source during the communication event.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "bytes",
+        "object_type": "long"
+      },
+      "communication.source.ip": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source ip",
+        "description": "The source IP address of the communication event.",
+        "examples": [
+          "192.0.2.0",
+          "2001:db8::"
+        ],
+        "object_name": "ip",
+        "object_type": "ip"
+      },
+      "communication.source.port": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source port",
+        "description": "The source port of the communication event.",
+        "examples": [
+          "80",
+          "443",
+          "22"
+        ],
+        "object_name": "port",
+        "object_type": "long"
+      },
+      "communication.source.mac": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source mac",
+        "description": "The source MAC address of the communication event.",
+        "examples": [
+          "00:0a:95:9d:68:16",
+          "00:0a:95:9d:68:17",
+          "00:0a:95:9d:68:18"
+        ],
+        "object_name": "mac",
+        "object_type": "keyword"
+      },
+      "communication.source.packets": {
+        "category": "communication",
+        "component": "source",
+        "caption": "source packets",
+        "description": "The number of packets sent by the source during the communication event.",
+        "examples": [
+          "100",
+          "200",
+          "300"
+        ],
+        "object_name": "packets",
+        "object_type": "long"
+      },
+      "communication.destination.address": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination address",
+        "description": "The destination address of the communication event.",
+        "examples": [
+          "192.0.2.1",
+          "2001:db8::1"
+        ],
+        "object_name": "address",
+        "object_type": "text"
+      },
+      "communication.destination.domain": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination domain",
+        "description": "The destination domain of the communication event.",
+        "examples": [
+          "destination-example.com",
+          "another-destination-example.com"
+        ],
+        "object_name": "domain",
+        "object_type": "text"
+      },
+      "communication.destination.bytes": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination bytes",
+        "description": "The number of bytes received by the destination during the communication event.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "bytes",
+        "object_type": "long"
+      },
+      "communication.destination.ip": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination ip",
+        "description": "The destination IP address of the communication event.",
+        "examples": [
+          "192.0.2.1",
+          "2001:db8::1"
+        ],
+        "object_name": "ip",
+        "object_type": "ip"
+      },
+      "communication.destination.port": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination port",
+        "description": "The destination port of the communication event.",
+        "examples": [
+          "80",
+          "443",
+          "22"
+        ],
+        "object_name": "port",
+        "object_type": "long"
+      },
+      "communication.destination.mac": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination mac",
+        "description": "The destination MAC address of the communication event.",
+        "examples": [
+          "00:0a:95:9d:68:19",
+          "00:0a:95:9d:68:1a",
+          "00:0a:95:9d:68:1b"
+        ],
+        "object_name": "mac",
+        "object_type": "keyword"
+      },
+      "communication.destination.packets": {
+        "category": "communication",
+        "component": "destination",
+        "caption": "destination packets",
+        "description": "The number of packets received by the destination during the communication event.",
+        "examples": [
+          "100",
+          "200",
+          "300"
+        ],
+        "object_name": "packets",
+        "object_type": "long"
+      }
+    }
+  ]
+}

--- a/schema/observability/logs/container.dictionary
+++ b/schema/observability/logs/container.dictionary
@@ -1,0 +1,177 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "container.image.name": {
+        "category": "container",
+        "component": "image",
+        "caption": "image name",
+        "description": "The name of the container image.",
+        "examples": [
+          "nginx",
+          "alpine",
+          "mysql"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "container.image.tag": {
+        "category": "container",
+        "component": "image",
+        "caption": "image tag",
+        "description": "The tag of the container image.",
+        "examples": [
+          "latest",
+          "1.0",
+          "1.0.1"
+        ],
+        "object_name": "tag",
+        "object_type": "keyword"
+      },
+      "container.image.hash": {
+        "category": "container",
+        "component": "image",
+        "caption": "image hash",
+        "description": "The hash of the container image.",
+        "examples": [
+          "sha256:a3ed95caeb02",
+          "sha256:5f70bf18a086",
+          "sha256:2f71b45e4e25"
+        ],
+        "object_name": "hash",
+        "object_type": "keyword"
+      },
+      "container.id": {
+        "category": "container",
+        "component": "general",
+        "caption": "container id",
+        "description": "The unique identifier of the container.",
+        "examples": [
+          "7a68bf16c748",
+          "5f19a2c77ac0",
+          "44f980dc8a45"
+        ],
+        "object_name": "id",
+        "object_type": "keyword"
+      },
+      "container.name": {
+        "category": "container",
+        "component": "general",
+        "caption": "container name",
+        "description": "The name of the container.",
+        "examples": [
+          "nginx_container",
+          "db_container",
+          "app_container"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "container.labels": {
+        "category": "container",
+        "component": "metadata",
+        "caption": "container labels",
+        "description": "The labels assigned to the container.",
+        "examples": [
+          "label1=value1",
+          "label2=value2",
+          "label3=value3"
+        ],
+        "object_name": "labels",
+        "object_type": "keyword"
+      },
+      "container.runtime": {
+        "category": "container",
+        "component": "runtime",
+        "caption": "container runtime",
+        "description": "The container runtime used (e.g., Docker, containerd).",
+        "examples": [
+          "Docker",
+          "containerd",
+          "cri-o"
+        ],
+        "object_name": "runtime",
+        "object_type": "keyword"
+      },
+      "container.memory.usage": {
+        "category": "container",
+        "component": "memory",
+        "caption": "memory usage",
+        "description": "The memory usage of the container in bytes.",
+        "examples": [
+          "1048576",
+          "2097152",
+          "4194304"
+        ],
+        "object_name": "usage",
+        "object_type": "float"
+      },
+      "container.network.ingress.bytes": {
+        "category": "container",
+        "component": "network",
+        "caption": "ingress bytes",
+        "description": "The number of bytes received by the container over the network.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "ingress_bytes",
+        "object_type": "long"
+      },
+      "container.network.egress.bytes": {
+        "category": "container",
+        "component": "network",
+        "caption": "egress bytes",
+        "description": "The number of bytes sent by the container over the network.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "egress_bytes",
+        "object_type": "long"
+      },
+      "container.cpu.usage": {
+        "category": "container",
+        "component": "cpu",
+        "caption": "cpu usage",
+        "description": "The CPU usage of the container as a percentage.",
+        "examples": [
+          "10.5",
+          "25.3",
+          "50.7"
+        ],
+        "object_name": "usage",
+        "object_type": "float"
+      },
+      "container.disk.read.bytes": {
+        "category": "container",
+        "component": "disk",
+        "caption": "disk read bytes",
+        "description": "The number of bytes read by the container from the disk.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "read_bytes",
+        "object_type": "long"
+      },
+      "container.disk.write.bytes": {
+        "category": "container",
+        "component": "disk",
+        "caption": "disk write bytes",
+        "description": "The number of bytes written by the container to the disk.",
+        "examples": [
+          "1024",
+          "2048",
+          "4096"
+        ],
+        "object_name": "write_bytes",
+        "object_type": "long"
+      }
+    }
+  ]
+}

--- a/schema/observability/logs/http.dictionary
+++ b/schema/observability/logs/http.dictionary
@@ -1,0 +1,233 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "http.user_agent": {
+        "category": "log",
+        "component": "http",
+        "caption": "user agent",
+        "description": "The user_agent field usually appears in the browser request. it often show up in web service logs coming from the parsed user agent string",
+        "examples": [
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X)",
+          "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0",
+          "Mobile/15E148 Safari/604.1"
+        ],
+        "object_name": "user_agent",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.url": {
+        "category": "log",
+        "component": "http",
+        "caption": "url",
+        "description": "URL field provide support for complete or partial URLs, and supports the inner scheme, domain, path ext.",
+        "examples": [
+          "https://schema.ocsf.io/",
+          "https://opensearch.org/docs/2.5/observing-your-data/index/"
+        ],
+        "object_name": "url",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.schema": {
+        "category": "log",
+        "component": "http",
+        "caption": "schema",
+        "description": "Scheme of the request, such as \"https\" or \"file\"",
+        "examples": [
+          "http",
+          "file"
+        ],
+        "object_name": "schema",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.flavor": {
+        "category": "log",
+        "component": "http",
+        "caption": "flavor",
+        "description": "The flavor field describes the HTTP version used for the request.",
+        "examples": [
+          "HTTP/1.1",
+          "HTTP/2"
+        ],
+        "object_name": "flavor",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.target": {
+        "category": "log",
+        "component": "http",
+        "caption": "target",
+        "description": "The target of the HTTP request, which is often the path section of the URL.",
+        "examples": [
+          "/index.html",
+          "/api/user"
+        ],
+        "object_name": "target",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.route": {
+        "category": "log",
+        "component": "http",
+        "caption": "route",
+        "description": "The route field represents the matched route of an HTTP request.",
+        "examples": [
+          "/user/:id",
+          "/product/:sku"
+        ],
+        "object_name": "route",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.client.ip": {
+        "category": "log",
+        "component": "http",
+        "caption": "client IP",
+        "description": "The IP address of the client that initiated the HTTP request.",
+        "examples": [
+          "192.0.2.0",
+          "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+        ],
+        "object_name": "client.ip",
+        "object_type": "ip"
+      }
+    },
+    {
+      "http.resent_count": {
+        "category": "log",
+        "component": "http",
+        "caption": "resent count",
+        "description": "The number of times the request has been resent.",
+        "examples": [
+          1,
+          2,
+          3
+        ],
+        "object_name": "resent_count",
+        "object_type": "integer"
+      }
+    },
+    {
+      "http.request.id": {
+        "category": "log",
+        "component": "http",
+        "caption": "request id",
+        "description": "Unique identifier for the HTTP request.",
+        "examples": ["12345", "67890"],
+        "object_name": "request.id",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.request.body.content": {
+        "category": "log",
+        "component": "http",
+        "caption": "request body content",
+        "description": "The content of the body of the HTTP request.",
+        "examples": ["{\"username\":\"testuser\",\"password\":\"password\"}", "username=testuser&password=password"],
+        "object_name": "request.body.content",
+        "object_type": "text"
+      }
+    },
+    {
+      "http.request.bytes": {
+        "category": "log",
+        "component": "http",
+        "caption": "request bytes",
+        "description": "The size of the HTTP request in bytes.",
+        "examples": [345, 567],
+        "object_name": "request.bytes",
+        "object_type": "long"
+      }
+    },
+    {
+      "http.request.method": {
+        "category": "log",
+        "component": "http",
+        "caption": "request method",
+        "description": "The HTTP method of the request, such as GET, POST, PUT, DELETE, etc.",
+        "examples": ["GET", "POST"],
+        "object_name": "request.method",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.request.referrer": {
+        "category": "log",
+        "component": "http",
+        "caption": "referrer",
+        "description": "The HTTP referrer, which specifies the URL from which the HTTP request was made.",
+        "examples": ["https://www.example.com", "https://www.testsite.com"],
+        "object_name": "request.referrer",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.request.mime_type": {
+        "category": "log",
+        "component": "http",
+        "caption": "mime type",
+        "description": "The MIME type of the HTTP request, which indicates the media type of the data.",
+        "examples": [
+          "application/json",
+          "text/html"
+        ],
+        "object_name": "request.mime_type",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.response.id": {
+        "category": "log",
+        "component": "http",
+        "caption": "response id",
+        "description": "Unique identifier for the HTTP response.",
+        "examples": ["12345", "67890"],
+        "object_name": "response.id",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.response.body.content": {
+        "category": "log",
+        "component": "http",
+        "caption": "response body content",
+        "description": "The content of the body of the HTTP response.",
+        "examples": [
+          "{\"status\":\"success\",\"data\":\"example\"}",
+          "status=success&data=example"
+        ],
+        "object_name": "response.body.content",
+        "object_type": "text"
+      } },
+    {
+      "http.response.bytes": {
+        "category": "log",
+        "component": "http",
+        "caption": "response bytes",
+        "description": "The size of the HTTP response in bytes.",
+        "examples": [345, 567],
+        "object_name": "response.bytes",
+        "object_type": "long"
+      }
+    },
+    { "http.response.status_code": {
+      "category": "log",
+      "component": "http",
+      "caption": "status code",
+      "description": "The HTTP status code of the response.",
+      "examples": [200, 404, 500],
+      "object_name": "response.status_code",
+      "object_type": "integer"
+    }}
+  ]
+}

--- a/schema/observability/logs/logs.dictionary
+++ b/schema/observability/logs/logs.dictionary
@@ -1,0 +1,159 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "severity.number": {
+        "category": "log",
+        "component": "severity",
+        "caption": "severity number",
+        "description": "Severity number associated with the log entry.",
+        "examples": [
+          "1",
+          "2",
+          "3"
+        ],
+        "object_name": "number",
+        "object_type": "long"
+      },
+      "severity.text": {
+        "category": "log",
+        "component": "severity",
+        "caption": "severity text",
+        "description": "Severity text associated with the log entry.",
+        "examples": [
+          "INFO",
+          "WARN",
+          "ERROR"
+        ],
+        "object_name": "text",
+        "object_type": "keyword"
+      },
+      "attributes.data_stream.*": {
+        "category": "log",
+        "component": "attributes",
+        "caption": "data stream attributes",
+        "description": "Data stream attributes for the log entry.",
+        "examples": [
+          "data_stream_1",
+          "data_stream_2",
+          "data_stream_3"
+        ],
+        "object_name": "data_stream",
+        "object_type": "keyword"
+      },
+      "body": {
+        "category": "log",
+        "component": "general",
+        "caption": "log body",
+        "description": "Log message content.",
+        "examples": [
+          "Error occured while trying to connect to the database",
+          "Server started successfully",
+          "User logged in"
+        ],
+        "object_name": "body",
+        "object_type": "text"
+      },
+      "@timestamp": {
+        "category": "log",
+        "component": "general",
+        "caption": "timestamp",
+        "description": "Log entry timestamp.",
+        "examples": [
+          "2023-06-14T18:00:00Z",
+          "2023-06-14T19:00:00Z",
+          "2023-06-14T20:00:00Z"
+        ],
+        "object_name": "timestamp",
+        "object_type": "date"
+      },
+      "observedTimestamp": {
+        "category": "log",
+        "component": "general",
+        "caption": "observed timestamp",
+        "description": "Observed timestamp of the log entry.",
+        "examples": [
+          "2023-06-14T18:00:00Z",
+          "2023-06-14T19:00:00Z",
+          "2023-06-14T20:00:00Z"
+        ],
+        "object_name": "observedTimestamp",
+        "object_type": "date"
+      },
+      "observerTime": {
+        "category": "log",
+        "component": "general",
+        "caption": "observer time",
+        "description": "Alias for `observedTimestamp`.",
+        "examples": [
+          "2023-06-14T18:00:00Z",
+          "2023-06-14T19:00:00Z",
+          "2023-06-14T20:00:00Z"
+        ],
+        "object_name": "observerTime",
+        "object_type": "alias"
+      },
+      "traceId": {
+        "category": "log",
+        "component": "trace",
+        "caption": "trace ID",
+        "description": "Trace ID associated with the log entry.",
+        "examples": [
+          "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+          "3fa85f64-5717-4562-b3fc-2c963f66afa8"
+        ],
+        "object_name": "traceId",
+        "object_type": "keyword",
+        "correlation_field": "traces.traceId"
+      },
+      "spanId": {
+        "category": "log",
+        "component": "trace",
+        "caption": "span ID",
+        "description": "Span ID associated with the log entry.",
+        "examples": [
+          "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+          "3fa85f64-5717-4562-b3fc-2c963f66afa7",
+          "3fa85f64-5717-4562-b3fc-2c963f66afa8"
+        ],
+        "object_name": "spanId",
+        "object_type": "keyword",
+        "correlation_field": "traces.spanId"
+      },
+      "schemaUrl": {
+        "category": "log",
+        "component": "general",
+        "caption": "schema URL",
+        "description": "URL of the schema used for the log entry.",
+        "examples": [
+          "https://myschema.org/schema_v1.json",
+          "https://myschema.org/schema_v2.json",
+          "https://myschema.org/schema_v3.json"
+        ],
+        "object_name": "schemaUrl",
+        "object_type": "keyword"
+      },
+      "instrumentationScope.*": {
+        "category": "log",
+        "component": "instrumentation",
+        "caption": "instrumentation scope",
+        "description": "Instrumentation scope information for the log entry.",
+        "examples": [],
+        "object_name": "instrumentationScope",
+        "object_type": "keyword"
+      },
+      "event.*": {
+        "category": "log",
+        "component": "event",
+        "caption": "event info",
+        "description": "Event information associated with the log entry.",
+        "examples": [],
+        "object_name": "event",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}
+

--- a/schema/observability/metrics/metrics.dictionary
+++ b/schema/observability/metrics/metrics.dictionary
@@ -1,0 +1,579 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "name": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Name",
+        "description": "The name of the metric.",
+        "examples": [
+          "http_requests_total",
+          "http_request_duration_seconds"
+        ],
+        "object_name": "name",
+        "object_type": "text/keyword"
+      },
+      "attributes.data_stream.dataset": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Data Stream Dataset",
+        "description": "Identifies the data set.",
+        "examples": [
+          "http_logs",
+          "system_metrics"
+        ],
+        "object_name": "attributes.data_stream.dataset",
+        "object_type": "keyword"
+      },
+      "attributes.data_stream.namespace": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Data Stream Namespace",
+        "description": "Specifies the namespace of the data stream.",
+        "examples": [
+          "web",
+          "database"
+        ],
+        "object_name": "attributes.data_stream.namespace",
+        "object_type": "keyword"
+      },
+      "attributes.data_stream.type": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Data Stream Type",
+        "description": "Specifies the type of data in the stream.",
+        "examples": [
+          "logs",
+          "metrics"
+        ],
+        "object_name": "attributes.data_stream.type",
+        "object_type": "keyword"
+      },
+      "description": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Description",
+        "description": "Description of the metric.",
+        "examples": [
+          "Total number of HTTP requests.",
+          "Duration of HTTP requests in seconds."
+        ],
+        "object_name": "description",
+        "object_type": "text/keyword"
+      },
+      "unit": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Unit",
+        "description": "The unit of the metric, e.g., bytes, seconds, etc.",
+        "examples": [
+          "seconds",
+          "bytes"
+        ],
+        "object_name": "unit",
+        "object_type": "keyword"
+      },
+      "kind": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Kind",
+        "description": "The kind of metric (e.g., gauge, counter, histogram, etc.).",
+        "examples": [
+          "gauge",
+          "counter"
+        ],
+        "object_name": "kind",
+        "object_type": "keyword"
+      },
+      "aggregationTemporality": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Aggregation Temporality",
+        "description": "Specifies the temporality of the aggregation (e.g., cumulative, delta).",
+        "examples": [
+          "cumulative",
+          "delta"
+        ],
+        "object_name": "aggregationTemporality",
+        "object_type": "keyword"
+      },
+      "monotonic": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Monotonic",
+        "description": "Indicates if the value can only increase.",
+        "examples": [
+          "true",
+          "false"
+        ],
+        "object_name": "monotonic",
+        "object_type": "boolean"
+      },
+      "startTime": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Start Time",
+        "description": "The start time of the metric collection.",
+        "examples": [
+          "2023-06-14T00:00:00Z",
+          "2023-06-14T01:00:00Z"
+        ],
+        "object_name": "startTime",
+        "object_type": "date"
+      },
+      "@timestamp": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Timestamp",
+        "description": "The timestamp when the metric was collected or received.",
+        "examples": [
+          "2023-06-14T00:05:00Z",
+          "2023-06-14T01:05:00Z"
+        ],
+        "object_name": "@timestamp",
+        "object_type": "date"
+      },
+      "observedTimestamp": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Observed Timestamp",
+        "description": "The precise timestamp of when the metric was observed.",
+        "examples": [
+          "2023-06-14T00:05:00.123456789Z",
+          "2023-06-14T01:05:00.123456789Z"
+        ],
+        "object_name": "observedTimestamp",
+        "object_type": "date_nanos"
+      },
+      "value.int": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Integer Value",
+        "description": "Integer value of the metric.",
+        "examples": [
+          "100",
+          "200"
+        ],
+        "object_name": "value.int",
+        "object_type": "integer"
+      },
+      "value.double": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Double Value",
+        "description": "Double/float value of the metric.",
+        "examples": [
+          "1.23",
+          "4.56"
+        ],
+        "object_name": "value.double",
+        "object_type": "double"
+      },
+      "buckets.count": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Buckets Count",
+        "description": "Count of the observed values in the bucket (used in histogram metrics).",
+        "examples": [
+          "1000",
+          "2000"
+        ],
+        "object_name": "buckets.count",
+        "object_type": "long"
+      },
+      "buckets.sum": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Buckets Sum",
+        "description": "Sum of the observed values in the bucket (used in histogram metrics).",
+        "examples": [
+          "10000.0",
+          "20000.0"
+        ],
+        "object_name": "buckets.sum",
+        "object_type": "double"
+      },
+      "buckets.max": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Buckets Max",
+        "description": "Maximum observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "100.0",
+          "200.0"
+        ],
+        "object_name": "buckets.max",
+        "object_type": "float"
+      },
+      "buckets.min": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Buckets Min",
+        "description": "Minimum observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "1.0",
+          "2.0"
+        ],
+        "object_name": "buckets.min",
+        "object_type": "float"
+      }
+    },
+    {
+      "bucketCount": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Bucket Count",
+        "description": "The total number of buckets.",
+        "examples": [
+          "10",
+          "20"
+        ],
+        "object_name": "bucketCount",
+        "object_type": "long"
+      },
+      "bucketCountsList": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Bucket Counts List",
+        "description": "A list of counts for multiple buckets.",
+        "examples": [
+          "[100, 200, 300]",
+          "[500, 600, 700]"
+        ],
+        "object_name": "bucketCountsList",
+        "object_type": "long"
+      },
+      "explicitBoundsList": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Explicit Bounds List",
+        "description": "A list of explicit bounds for histogram metrics.",
+        "examples": [
+          "[0.5, 0.7, 1.0]",
+          "[0.1, 0.2, 0.3]"
+        ],
+        "object_name": "explicitBoundsList",
+        "object_type": "float"
+      },
+      "explicitBoundsCount": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Explicit Bounds Count",
+        "description": "Count of explicit bounds.",
+        "examples": [
+          "3",
+          "4"
+        ],
+        "object_name": "explicitBoundsCount",
+        "object_type": "float"
+      },
+      "quantiles.quantile": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Quantile",
+        "description": "The quantile value (e.g., 0.95 for 95th percentile).",
+        "examples": [
+          "0.95",
+          "0.99"
+        ],
+        "object_name": "quantiles.quantile",
+        "object_type": "double"
+      },
+      "quantiles.value": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Quantile Value",
+        "description": "The value at the specified quantile.",
+        "examples": [
+          "10.0",
+          "20.0"
+        ],
+        "object_name": "quantiles.value",
+        "object_type": "double"
+      },
+      "quantileValuesCount": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Quantile Values Count",
+        "description": "Count of quantile values.",
+        "examples": [
+          "5",
+          "10"
+        ],
+        "object_name": "quantileValuesCount",
+        "object_type": "long"
+      },
+      "positiveBuckets.count": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Positive Buckets Count",
+        "description": "Count of positive observed values in the bucket (used in histogram metrics).",
+        "examples": [
+          "100",
+          "200"
+        ],
+        "object_name": "positiveBuckets.count",
+        "object_type": "long"
+      },
+      "positiveBuckets.max": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Positive Buckets Max",
+        "description": "Maximum positive observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "100.0",
+          "200.0"
+        ],
+        "object_name": "positiveBuckets.max",
+        "object_type": "float"
+      },
+      "positiveBuckets.min": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Positive Buckets Min",
+        "description": "Minimum positive observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "1.0",
+          "2.0"
+        ],
+        "object_name": "positiveBuckets.min",
+        "object_type": "float"
+      },
+      "negativeBuckets.count": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Negative Buckets Count",
+        "description": "Count of negative observed values in the bucket (used in histogram metrics).",
+        "examples": [
+          "100",
+          "200"
+        ],
+        "object_name": "negativeBuckets.count",
+        "object_type": "long"
+      },
+      "negativeBuckets.max": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Negative Buckets Max",
+        "description": "Maximum negative observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "-100.0",
+          "-200.0"
+        ],
+        "object_name": "negativeBuckets.max",
+        "object_type": "float"
+      },
+      "negativeBuckets.min": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Negative Buckets Min",
+        "description": "Minimum negative observed value in the bucket (used in histogram metrics).",
+        "examples": [
+          "-1.0",
+          "-2.0"
+        ],
+        "object_name": "negativeBuckets.min",
+        "object_type": "float"
+      },
+      "negativeOffset": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Negative Offset",
+        "description": "The offset for negative values in histogram metrics.",
+        "examples": [
+          "-10",
+          "-20"
+        ],
+        "object_name": "negativeOffset",
+        "object_type": "integer"
+      },
+      "positiveOffset": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Positive Offset",
+        "description": "The offset for positive values in histogram metrics.",
+        "examples": [
+          "10",
+          "20"
+        ],
+        "object_name": "positiveOffset",
+        "object_type": "integer"
+      },
+      "zeroCount": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Zero Count",
+        "description": "Count of zero values.",
+        "examples": [
+          "100",
+          "200"
+        ],
+        "object_name": "zeroCount",
+        "object_type": "long"
+      },
+      "scale": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Scale",
+        "description": "The scaling factor for the metric values.",
+        "examples": [
+          "100",
+          "200"
+        ],
+        "object_name": "scale",
+        "object_type": "long"
+      },
+      "max": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Max",
+        "description": "The maximum value of the metric.",
+        "examples": [
+          "100.0",
+          "200.0"
+        ],
+        "object_name": "max",
+        "object_type": "float"
+      },
+      "min": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Min",
+        "description": "The minimum value of the metric.",
+        "examples": [
+          "1.0",
+          "2.0"
+        ],
+        "object_name": "min",
+        "object_type": "float"
+      },
+      "sum": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Sum",
+        "description": "The sum of the metric values.",
+        "examples": [
+          "1000.0",
+          "2000.0"
+        ],
+        "object_name": "sum",
+        "object_type": "float"
+      },
+      "count": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Count",
+        "description": "The total count of the metric observations.",
+        "examples": [
+          "10000",
+          "20000"
+        ],
+        "object_name": "count",
+        "object_type": "long"
+      }
+    },
+    {
+      "exemplar.time": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Exemplar Time",
+        "description": "The timestamp of the exemplar observation.",
+        "examples": [
+          "2023-06-14T00:10:00Z",
+          "2023-06-14T01:10:00Z"
+        ],
+        "object_name": "exemplar.time",
+        "object_type": "date"
+      },
+      "exemplar.traceId": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Exemplar Trace ID",
+        "description": "The trace ID associated with the exemplar.",
+        "examples": [
+          "1234567890abcdef",
+          "0987654321fedcba"
+        ],
+        "object_name": "exemplar.traceId",
+        "object_type": "keyword",
+        "correlation_field": "traces.traceId"
+      },
+      "exemplar.spanId": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Exemplar Span ID",
+        "description": "The span ID associated with the exemplar.",
+        "examples": [
+          "abcdef1234567890",
+          "fedcba0987654321"
+        ],
+        "object_name": "exemplar.spanId",
+        "object_type": "keyword",
+        "correlation_field": "traces.spanId"
+
+      },
+      "instrumentationScope.name": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Instrumentation Scope Name",
+        "description": "The name of the instrumentation scope.",
+        "examples": [
+          "serviceA",
+          "serviceB"
+        ],
+        "object_name": "instrumentationScope.name",
+        "object_type": "text/keyword"
+      },
+      "instrumentationScope.version": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Instrumentation Scope Version",
+        "description": "The version of the instrumentation scope.",
+        "examples": [
+          "1.0.0",
+          "2.0.0"
+        ],
+        "object_name": "instrumentationScope.version",
+        "object_type": "text/keyword"
+      },
+      "instrumentationScope.droppedAttributesCount": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Dropped Attributes Count",
+        "description": "The count of dropped attributes in the instrumentation scope.",
+        "examples": [
+          "10",
+          "20"
+        ],
+        "object_name": "instrumentationScope.droppedAttributesCount",
+        "object_type": "integer"
+      },
+      "instrumentationScope.schemaUrl": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Instrumentation Scope Schema URL",
+        "description": "The URL of the schema for the instrumentation scope.",
+        "examples": [
+          "https://example.com/schema",
+          "https://example.com/schema2"
+        ],
+        "object_name": "instrumentationScope.schemaUrl",
+        "object_type": "text/keyword"
+      },
+      "schemaUrl": {
+        "category": "metrics",
+        "component": "metrics",
+        "caption": "Schema URL",
+        "description": "The URL of the schema for the metric.",
+        "examples": [
+          "https://example.com/metric-schema",
+          "https://example.com/metric-schema2"
+        ],
+        "object_name": "schemaUrl",
+        "object_type": "text/keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/traces/services.dictionary
+++ b/schema/observability/traces/services.dictionary
@@ -1,0 +1,105 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "destination.domain": {
+        "category": "services",
+        "component": "services",
+        "caption": "Destination Domain",
+        "description": "The domain of the destination.",
+        "examples": [
+          "example.com",
+          "api.service.com"
+        ],
+        "object_name": "destination.domain",
+        "object_type": "keyword"
+      },
+      "destination.resource": {
+        "category": "services",
+        "component": "services",
+        "caption": "Destination Resource",
+        "description": "The resource of the destination.",
+        "examples": [
+          "/api/v1/resource",
+          "/home/index.html"
+        ],
+        "object_name": "destination.resource",
+        "object_type": "keyword"
+      },
+      "hashId": {
+        "category": "services",
+        "component": "services",
+        "caption": "Hash ID",
+        "description": "The hash ID for the service.",
+        "examples": [
+          "a1b2c3",
+          "d4e5f6"
+        ],
+        "object_name": "hashId",
+        "object_type": "keyword"
+      },
+      "serviceName": {
+        "category": "services",
+        "component": "services",
+        "caption": "Service Name",
+        "description": "The name of the service.",
+        "examples": [
+          "serviceA",
+          "serviceB"
+        ],
+        "object_name": "serviceName",
+        "object_type": "keyword"
+      },
+      "kind": {
+        "category": "services",
+        "component": "services",
+        "caption": "Kind",
+        "description": "The kind of the service.",
+        "examples": [
+          "web",
+          "microservice"
+        ],
+        "object_name": "kind",
+        "object_type": "keyword"
+      },
+      "target.domain": {
+        "category": "services",
+        "component": "services",
+        "caption": "Target Domain",
+        "description": "The domain of the target.",
+        "examples": [
+          "example.com",
+          "api.service.com"
+        ],
+        "object_name": "target.domain",
+        "object_type": "keyword"
+      },
+      "target.resource": {
+        "category": "services",
+        "component": "services",
+        "caption": "Target Resource",
+        "description": "The resource of the target.",
+        "examples": [
+          "/api/v1/resource",
+          "/home/index.html"
+        ],
+        "object_name": "target.resource",
+        "object_type": "keyword"
+      },
+      "traceGroupName": {
+        "category": "services",
+        "component": "services",
+        "caption": "Trace Group Name",
+        "description": "The trace group name associated with the service.",
+        "examples": [
+          "traceGroupA",
+          "traceGroupB"
+        ],
+        "object_name": "traceGroupName",
+        "object_type": "keyword",
+        "correlation_field": "tracegroups.traceGroup"
+      }
+    }
+  ]
+}

--- a/schema/observability/traces/tracegroups.dictionary
+++ b/schema/observability/traces/tracegroups.dictionary
@@ -1,0 +1,56 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "traceGroup": {
+        "category": "traceGroups",
+        "component": "traceGroups",
+        "caption": "Trace Group",
+        "description": "The trace group name.",
+        "examples": [
+          "groupA",
+          "groupB"
+        ],
+        "object_name": "traceGroup",
+        "object_type": "keyword"
+      },
+      "traceGroupFields.endTime": {
+        "category": "traceGroups",
+        "component": "traceGroups",
+        "caption": "Trace Group End Time",
+        "description": "The end time of the trace group.",
+        "examples": [
+          1623704400000,
+          1623708000000
+        ],
+        "object_name": "traceGroupFields.endTime",
+        "object_type": "long"
+      },
+      "traceGroupFields.durationInNanos": {
+        "category": "traceGroups",
+        "component": "traceGroups",
+        "caption": "Trace Group Duration",
+        "description": "The duration of the trace group in nanoseconds.",
+        "examples": [
+          123456789,
+          987654321
+        ],
+        "object_name": "traceGroupFields.durationInNanos",
+        "object_type": "long"
+      },
+      "traceGroupFields.statusCode": {
+        "category": "traceGroups",
+        "component": "traceGroups",
+        "caption": "Trace Group Status Code",
+        "description": "The status code of the trace group.",
+        "examples": [
+          200,
+          404
+        ],
+        "object_name": "traceGroupFields.statusCode",
+        "object_type": "integer"
+      }
+    }
+  ]
+}

--- a/schema/observability/traces/traces.dictionary
+++ b/schema/observability/traces/traces.dictionary
@@ -1,0 +1,333 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "traceId": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Trace ID",
+        "description": "The trace ID.",
+        "examples": [
+          "1234567890",
+          "0987654321"
+        ],
+        "object_name": "traceId",
+        "object_type": "keyword"
+      },
+      "spanId": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Span ID",
+        "description": "The span ID.",
+        "examples": [
+          "spanA",
+          "spanB"
+        ],
+        "object_name": "spanId",
+        "object_type": "keyword"
+      },
+      "traceState": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Trace State",
+        "description": "The trace state.",
+        "examples": [
+          "active",
+          "completed"
+        ],
+        "object_name": "traceState",
+        "object_type": "text"
+      },
+      "parentSpanId": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Parent Span ID",
+        "description": "The parent span ID.",
+        "examples": [
+          "parentSpanA",
+          "parentSpanB"
+        ],
+        "object_name": "parentSpanId",
+        "object_type": "keyword"
+      },
+      "name": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Trace Name",
+        "description": "The name of the trace.",
+        "examples": [
+          "trace1",
+          "trace2"
+        ],
+        "object_name": "name",
+        "object_type": "keyword"
+      },
+      "kind": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Trace Kind",
+        "description": "The kind of the trace.",
+        "examples": [
+          "request",
+          "database"
+        ],
+        "object_name": "kind",
+        "object_type": "keyword"
+      },
+      "startTime": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Start Time",
+        "description": "The start time of the trace.",
+        "examples": [
+          "2023-06-14T00:00:00Z",
+          "2023-06-14T12:00:00Z"
+        ],
+        "object_name": "startTime",
+        "object_type": "date_nanos"
+      },
+      "endTime": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "End Time",
+        "description": "The end time of the trace.",
+        "examples": [
+          "2023-06-14T01:00:00Z",
+          "2023-06-14T13:00:00Z"
+        ],
+        "object_name": "endTime",
+        "object_type": "date_nanos"
+      },
+      "droppedAttributesCount": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Dropped Attributes Count",
+        "description": "The count of dropped attributes.",
+        "examples": [
+          10,
+          20
+        ],
+        "object_name": "droppedAttributesCount",
+        "object_type": "long"
+      },
+      "droppedEventsCount": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Dropped Events Count",
+        "description": "The count of dropped events.",
+        "examples": [
+          5,
+          15
+        ],
+        "object_name": "droppedEventsCount",
+        "object_type": "long"
+      },
+      "droppedLinksCount": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Dropped Links Count",
+        "description": "The count of dropped links.",
+        "examples": [
+          3,
+          8
+        ],
+        "object_name": "droppedLinksCount",
+        "object_type": "long"
+      },
+      "status.code": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Status Code",
+        "description": "The status code of the trace.",
+        "examples": [
+          200,
+          500
+        ],
+        "object_name": "status.code",
+        "object_type": "long"
+      },
+      "status.message": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Status Message",
+        "description": "The status message of the trace.",
+        "examples": [
+          "Success",
+          "Error"
+        ],
+        "object_name": "status.message",
+        "object_type": "keyword"
+      },
+      "attributes.serviceName": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Service Name",
+        "description": "The name of the service.",
+        "examples": [
+          "serviceA",
+          "serviceB"
+        ],
+        "object_name": "attributes.serviceName",
+        "object_type": "keyword",
+        "correlation_field": "services.serviceName"
+      },
+      "attributes.data_stream.dataset": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Data Stream Dataset",
+        "description": "The dataset of the data stream.",
+        "examples": [
+          "datasetA",
+          "datasetB"
+        ],
+        "object_name": "attributes.data_stream.dataset",
+        "object_type": "keyword"
+      },
+      "attributes.data_stream.namespace": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Data Stream Namespace",
+        "description": "The namespace of the data stream.",
+        "examples": [
+          "namespaceA",
+          "namespaceB"
+        ],
+        "object_name": "attributes.data_stream.namespace",
+        "object_type": "keyword"
+      },
+      "events.name": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Event Name",
+        "description": "The name of the event.",
+        "examples": [
+          "eventA",
+          "eventB"
+        ],
+        "object_name": "events.name",
+        "object_type": "keyword"
+      },
+      "events.@timestamp": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Event Timestamp",
+        "description": "The timestamp of the event.",
+        "examples": [
+          "2023-06-14T00:00:00Z",
+          "2023-06-14T12:00:00Z"
+        ],
+        "object_name": "events.@timestamp",
+        "object_type": "date_nanos"
+      },
+      "events.observedTimestamp": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Event Observed Timestamp",
+        "description": "The observed timestamp of the event.",
+        "examples": [
+          "2023-06-14T01:00:00Z",
+          "2023-06-14T13:00:00Z"
+        ],
+        "object_name": "events.observedTimestamp",
+        "object_type": "date_nanos"
+      },
+      "links.traceId": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Link Trace ID",
+        "description": "The trace ID of the link.",
+        "examples": [
+          "linkTraceA",
+          "linkTraceB"
+        ],
+        "object_name": "links.traceId",
+        "object_type": "keyword"
+      },
+      "links.spanId": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Link Span ID",
+        "description": "The span ID of the link.",
+        "examples": [
+          "linkSpanA",
+          "linkSpanB"
+        ],
+        "object_name": "links.spanId",
+        "object_type": "keyword"
+      },
+      "links.traceState": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Link Trace State",
+        "description": "The trace state of the link.",
+        "examples": [
+          "linkActive",
+          "linkCompleted"
+        ],
+        "object_name": "links.traceState",
+        "object_type": "text"
+      },
+      "instrumentationScope.name": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Instrumentation Scope Name",
+        "description": "The name of the instrumentation scope.",
+        "examples": [
+          "scopeA",
+          "scopeB"
+        ],
+        "object_name": "instrumentationScope.name",
+        "object_type": "keyword"
+      },
+      "instrumentationScope.version": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Instrumentation Scope Version",
+        "description": "The version of the instrumentation scope.",
+        "examples": [
+          "versionA",
+          "versionB"
+        ],
+        "object_name": "instrumentationScope.version",
+        "object_type": "keyword"
+      },
+      "instrumentationScope.droppedAttributesCount": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Instrumentation Scope Dropped Attributes Count",
+        "description": "The count of dropped attributes in the instrumentation scope.",
+        "examples": [
+          2,
+          4
+        ],
+        "object_name": "instrumentationScope.droppedAttributesCount",
+        "object_type": "integer"
+      },
+      "instrumentationScope.schemaUrl": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Instrumentation Scope Schema URL",
+        "description": "The schema URL of the instrumentation scope.",
+        "examples": [
+          "https://example.com/schemaA",
+          "https://example.com/schemaB"
+        ],
+        "object_name": "instrumentationScope.schemaUrl",
+        "object_type": "keyword"
+      },
+      "schemaUrl": {
+        "category": "traces",
+        "component": "trace",
+        "caption": "Schema URL",
+        "description": "The schema URL of the trace.",
+        "examples": [
+          "https://example.com/schema1",
+          "https://example.com/schema2"
+        ],
+        "object_name": "schemaUrl",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/traces/traces.mapping
+++ b/schema/observability/traces/traces.mapping
@@ -214,7 +214,7 @@
       {
         "field": "serviceName",
         "foreign-schema": "services",
-        "foreign-field": "spanId"
+        "foreign-field": "serviceName"
       }
     ]
   }


### PR DESCRIPTION
### Description

For each field inside the index/component template fields set the dictionary content must exist:
This info includes
 - catalog / category / component info
 - name / caption
 - description / examples
 - object type 
 - correlation reference field (if this is a foreign key)
```
      "attributes.serviceName": {
        "category": "traces",
        "component": "trace",
        "caption": "Service Name",
        "description": "The name of the service.",
        "examples": [
          "serviceA",
          "serviceB"
        ],
        "object_name": "attributes.serviceName",
        "object_type": "keyword",
        "correlation_field": "services.serviceName"
      }
```

### Issues Resolved
- https://github.com/opensearch-project/opensearch-catalog/issues/20

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
