### PR TITLE
add http Semantic-Convention for metrics & spans

### DIFF
--- a/docs/schema/observability/Semantic-Convention.md
+++ b/docs/schema/observability/Semantic-Convention.md
@@ -1,0 +1,91 @@
+## What Do We Understand By Semantic Conventions?
+Semantic conventions refer to the commonly accepted significance of words and phrases within a specific language or culture. They facilitate effective communication by establishing a mutual comprehension of our symbolic representations.
+
+## What Is The Role Of Semantic Conventions In OTEL?
+In OpenTelemetry (OTEL), semantic conventions are crucial as they prescribe how data should be structured and exchanged among different system components. 
+Semantic conventions ensure consistent data interpretation and processing by various services and tools.
+
+They can be used to outline data structure and the connections between different data components. A convention, for example, may stipulate that all data related to a specific resource be clustered together. This allows an analysis tool to readily identify all data items related to a particular resource without individually scrutinizing each data item.
+
+Semantic conventions can also define data significance: a convention might determine that a certain data element represents a resource's temperature. 
+This enables an analysis tool to automatically comprehend the data item's meaning, eliminating the need for human expertise.
+
+## What Are The Metric Semantic Conventions?
+Semantic conventions standardize metric meanings across diverse software implementations. Having commonly defined metrics simplifies comparing results from various tools. OpenTelemetry has created a set of metric semantic conventions applicable to any software that collects or presents metric data.
+
+These conventions provide a standard set of core dimensions to be employed when recording metric data, including name, description, unit, and type, also suggesting labels to add more detail to the data. Adherence to these norms results in easily understood metrics that can be efficiently compared.
+
+The metric semantic conventions are a part of the OpenTelemetry project, which aims to standardize the collection and storage of telemetry data. The objective is to simplify developers' work with telemetry data from diverse sources.
+
+Along with metric semantic conventions, the OpenTelemetry team has also established standards for logging and tracing data. 
+
+
+## What Are The Resource Semantic Conventions?
+Resource semantic conventions consist of agreed-upon rules for representing monitored resources in telemetry data. These rules allow vendors to ensure their monitoring data is compatible with different systems and tools.
+
+The Resource Semantic Conventions focus on four major areas:
+
+- **Metrics**: Data about a resource's performance. Examples include response time, throughput, and error rate.
+- **Spans**: Data about a trace's internal interactions inside a logical unit of work (AKA transaction) . 
+- **Attributes**: Information about a resource's physical or logical traits. Examples include CPU usage, memory consumption, and network bandwidth.
+- **Logs**: A chronological record of events associated with a resource. Logs are useful for auditing or debugging.
+- **Events**: A record of a resource's activities. Events aid in troubleshooting or provide context to other telemetry data. Examples include starting or stopping a service, a disk error, or a user logging in.
+
+### Attributes:
+Attributes describe the data's dimensions. For example, network data might include source and destination IP addresses, port numbers, and so forth. 
+Metadata about the data itself, such as timestamp or logging level, can also be attributed. Attributes are stored in AttributeMaps, which map attribute keys to values. 
+The keys can be strings or other data types, while the values can be any data type that can be represented as a JSON value.
+
+### Events: 
+Events serve as significant timestamps or system states in OpenTelemetry. They can be either manually or automatically generated and contain metadata and any relevant data collected at the time of the event.
+Events can track system progress through its lifecycle or flag state changes indicative of potential issues.
+
+## Why Are These Constants Significant?
+In OpenTelemetry, constants are crucial as they establish a set of definitions and resource types universally accepted, thereby ensuring compatibility between different software implementations.
+Metric and resource semantic conventions define a uniform way to label metrics and resources, which is essential for aggregating data from various sources.
+These constants give developers confidence that their data will be compatible with other systems using the same conventions.
+
+OpenTelemetry's goal is to provide a vendor-neutral way to instrument cloud-native software. This goal is reliant on shared building blocks across all implementations.
+Constants are one of these building blocks and are crucial in ensuring that data from different sources can be aggregated and analyzed consistently.
+
+
+---
+
+
+### Semantic Conventions are defined for the following areas:
+
+* [Traces - HTTP](../../../schema/observability/traces/http.mapping): Semantic Conventions for Traces HTTP client and server operations.
+* [Metrics HTTP](../../../schema/observability/metrics/http.mapping): Semantic Conventions for Metrics HTTP client and server operations.
+
+Semantic Conventions by signals: (OpenTelemetry)
+
+* [Resource](https://github.com/open-telemetry/semantic-conventions/tree/main/docs/resource): Semantic Conventions for resources.
+* [Trace](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/trace-general.md): Semantic Conventions for traces and spans.
+* [Metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics-general.md): Semantic Conventions for metrics.
+* [Events](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/events-general.md): Semantic Conventions for event data.
+
+---
+
+## Trace Conventions
+
+In OpenTelemetry spans can be created freely and it’s up to the implementor to annotate them with attributes specific to the represented operation.
+Spans represent specific operations in and between systems. Some of these operations represent calls that use well-known protocols like HTTP or database calls.
+Depending on the protocol and the type of operation, additional information is needed to represent and analyze a span correctly in monitoring systems.
+
+The following semantic conventions for spans are defined:
+
+* [Traces - HTTP](../../../schema/observability/traces/http.mapping): For HTTP client and server spans.
+* [Samples](../observability/traces/samples/http)
+
+
+---
+
+## Metrics Conventions
+
+The following semantic conventions surrounding metrics are defined:
+
+* [Metrics HTTP](../../../schema/observability/metrics/http.mapping): For HTTP client and server metrics.
+* [Samples](../observability/metrics/samples/http)
+---
+
+> For additional details check the [openTelemetry semantic convention repository](https://github.com/open-telemetry/semantic-conventions/tree/main/semantic_conventions) 

--- a/docs/schema/observability/metrics/samples/http/http_client_duration_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_client_duration_histogram.json
@@ -1,0 +1,80 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.client.duration In Nanos in the events",
+  "sum": 3136355061,
+  "unit": "seconds",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "aggr_duration": 26709005000,
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.client.duration",
+    "http": {
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "client": {
+        "server.address": "example.com",
+        "server.port": 80,
+        "server.socket.address": "127.0.0.1"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_client_request_size_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_client_request_size_histogram.json
@@ -1,0 +1,80 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.client.request.size In Bytes in the events",
+  "sum": 3136355061,
+  "unit": "bytes",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.client.request.size",
+    "http": {
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "client": {
+        "server.address": "example.com",
+        "server.port": 80,
+        "server.socket.address": "10.5.3.2",
+        "url.schema": "http"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_client_response_size_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_client_response_size_histogram.json
@@ -1,0 +1,81 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.client.response.size In Bytes in the events",
+  "sum": 3136355061,
+  "unit": "bytes",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.client.response.size",
+    "http": {
+      "route": "/users/:userID?",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "client": {
+        "server.address": "example.com",
+        "server.socket.address": "10.5.3.2",
+        "server.port": 80,
+        "url.schema": "http"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_server_active_requests.json
+++ b/docs/schema/observability/metrics/samples/http/http_server_active_requests.json
@@ -1,0 +1,63 @@
+{
+  "unit": "ms",
+  "exemplars": [],
+  "kind": "GAUGE",
+  "name": "lastLatency",
+  "flags": 0,
+  "description": "The last API latency observed at collection interval",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "value.double": 0.0,
+  "resource": {
+    "cloud@account@id": "123367104812",
+    "process@pid": 1,
+    "host@arch": "amd64",
+    "host@id": "i-0005de88c8ebe7dbb",
+    "host@image@id": "ami-093d4bc1f6d4a890b",
+    "telemetry@sdk@version": "1.19.0",
+    "service@name": "AOCDockerDemoService",
+    "process@runtime@name": "OpenJDK Runtime Environment",
+    "os@type": "linux",
+    "cloud@availability_zone": "us-west-2b",
+    "host@type": "c5.2xlarge",
+    "cloud@provider": "aws",
+    "telemetry@sdk@language": "java",
+    "host@name": "ip-172-16-42-233.amazon.com",
+    "process@runtime@description": "Debian OpenJDK 64-Bit Server VM 17.0.4+8-Debian-1deb11u1",
+    "service@namespace": "AOCDockerDemo",
+    "cloud@region": "us-west-2",
+    "process@executable@path": "/usr/lib/jvm/java-17-openjdk-amd64/bin/java",
+    "process@command_line": "/usr/lib/jvm/java-17-openjdk-amd64/bin/java -javaagent:/aws-observability/classpath/aws-opentelemetry-agent-1.19.0-SNAPSHOT.jar",
+    "process@runtime@version": "17.0.4+8-Debian-1deb11u1",
+    "cloud@platform": "aws_ec2",
+    "telemetry@sdk@name": "opentelemetry",
+    "container@id": "71301ad845e7d082911d846ac9af3cd9ba4f2144d82d7ac0dfd51f335b256a61",
+    "telemetry@auto@version": "1.19.0-aws-SNAPSHOT",
+    "os@description": "Linux 5.4.225-139.416.amzn2int.x86_64"
+  },
+  "attributes": {
+    "statusCode": "",
+    "apiName": "",
+    "serviceName": "AOCDockerDemoService"
+  },
+
+  "instrumentationScope": {
+    "version": "1.0",
+    "name": "aws-otel",
+    "schemaUrl": "https://opentelemetry.io/schemas/1.13.0",
+    "attributes": {
+      "identification": "aws-ec2",
+      "histogram_key": "http.server.active_requests",
+      "http": {
+        "request": {
+          "method": "GET"
+        },
+        "server": {
+          "address": "example.com",
+          "port": 80,
+          "url.schema": "http"
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_server_duration_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_server_duration_histogram.json
@@ -1,0 +1,87 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.server.duration In Nanos in the events",
+  "sum": 3136355061,
+  "unit": "seconds",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "aggr_duration": 26709005000,
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.server.duration",
+    "http": {
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "client": {
+        "server.socket.address": "127.0.0.1",
+        "server.address": "example.com",
+        "server.port": 80
+      },
+      "server": {
+        "route": "/users/:userID?",
+        "address": "example.com",
+        "port": 80,
+        "socket.address": "127.0.0.1",
+        "url.schema": "http"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_server_request_size_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_server_request_size_histogram.json
@@ -1,0 +1,79 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.server.request.size In Bytes in the events",
+  "sum": 3136355061,
+  "unit": "bytes",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.server.request.size",
+    "http": {
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "server": {
+        "address": "example.com",
+        "port": 80,
+        "url.schema": "http"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/metrics/samples/http/http_server_response_size_histogram.json
+++ b/docs/schema/observability/metrics/samples/http/http_server_response_size_histogram.json
@@ -1,0 +1,80 @@
+{
+  "max": 652094078,
+  "kind": "HISTOGRAM",
+  "buckets": [
+    {
+      "min": 3.4028234663852886e+38,
+      "max": 0,
+      "count": 0
+    },
+    {
+      "min": 0,
+      "max": 10000000,
+      "count": 0
+    },
+    {
+      "min": 10000000,
+      "max": 50000000,
+      "count": 5
+    },
+    {
+      "min": 50000000,
+      "max": 100000000,
+      "count": 1
+    },
+    {
+      "min": 100000000,
+      "max": 3.4028234663852886e+38,
+      "count": 10
+    }
+  ],
+  "count": 16,
+  "bucketCountsList": [
+    0,
+    0,
+    5,
+    1,
+    10
+  ],
+  "description": "Histogram of http.server.response.size In Bytes in the events",
+  "sum": 3136355061,
+  "unit": "bytes",
+  "aggregationTemporality": "AGGREGATION_TEMPORALITY_DELTA",
+  "min": 44606914,
+  "bucketCounts": 5,
+  "name": "histogram",
+  "startTime": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsCount": 4,
+  "@timestamp": "2023-01-20T05:16:16.425669Z",
+  "explicitBoundsList": [
+    0,
+    10000000,
+    50000000,
+    100000000
+  ],
+  "attributes": {
+    "serviceName": "AOCDockerDemoService",
+    "histogram_key": "http.server.response.size",
+    "http": {
+      "route": "/users/:userID?",
+      "request": {
+        "method": "GET"
+      },
+      "response": {
+        "status_code": "200"
+      },
+      "network.protocol.name": "HTTP",
+      "network.protocol.version": "1.1",
+      "server": {
+        "address": "example.com",
+        "port": 80,
+        "url.schema": "http"
+      }
+    },
+    "data_stream": {
+      "dataset": "histogram",
+      "namespace": "production",
+      "type": "metric"
+    }
+  }
+}

--- a/docs/schema/observability/traces/samples/http/traceWithHttp.json
+++ b/docs/schema/observability/traces/samples/http/traceWithHttp.json
@@ -1,0 +1,90 @@
+{
+  "traceId": "4fa04f117be100f476b175e41096e736",
+  "spanId": "e275ac9d21929e9b",
+  "traceState": [],
+  "parentSpanId": "",
+  "name": "client_checkout",
+  "kind": "INTERNAL",
+  "startTime": "2021-11-13T20:20:39+00:00",
+  "@timestamp": "2021-11-13T20:20:39+00:00",
+  "endTime": "2021-11-14T20:10:41+00:00",
+  "droppedAttributesCount": 0,
+  "droppedEventsCount": 0,
+  "droppedLinksCount": 0,
+  "resource": {
+    "telemetry@sdk@name": "opentelemetry",
+    "telemetry@sdk@language": "python",
+    "telemetry@sdk@version": "0.14b0",
+    "service@name": "frontend-client",
+    "host@hostname": "ip-172-31-10-8.us-west-2.compute.internal"
+  },
+  "status": {
+    "code": 0
+  },
+  "attributes": {
+    "serviceName": "customer",
+    "http": {
+      "user_agent": {
+        "original": "Mozilla/5.0"
+      },
+      "network": {
+        "transport": "tcp",
+        "type": "ipv4",
+        "protocol": {
+          "name": "http",
+          "version": "1.1"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "method_original": "GET",
+        "body": {
+          "size": 0
+        }
+      },
+      "response": {
+        "status_code": "200",
+        "body": {
+          "size": 500
+        }
+      },
+      "client": {
+        "server": {
+          "socket": {
+            "address": "192.168.0.1",
+            "domain": "example.com",
+            "port": 80
+          },
+          "address": "192.168.0.1",
+          "port": 80
+        },
+        "resend_count": 0,
+        "url": {
+          "full": "http://example.com"
+        }
+      },
+      "server": {
+        "route": "/index",
+        "address": "192.168.0.2",
+        "port": 8080,
+        "socket": {
+          "address": "192.168.0.2",
+          "port": 8080
+        },
+        "client": {
+          "address": "192.168.0.1",
+          "port": 80,
+          "socket": {
+            "address": "192.168.0.1",
+            "port": 80
+          }
+        },
+        "url": {
+          "path": "/index",
+          "query": "?id=123",
+          "schema": "http"
+        }
+      }
+    }
+  }
+}

--- a/schema/observability/metrics/http.dictionary
+++ b/schema/observability/metrics/http.dictionary
@@ -1,0 +1,130 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "http.network.protocol.name": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Protocol Name",
+        "description": "The name of network protocol.",
+        "examples": [
+          "http",
+          "https"
+        ],
+        "object_name": "http.network.protocol.name",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.network.protocol.version": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Protocol Version",
+        "description": "The version of network protocol.",
+        "examples": [
+          "1.1",
+          "2"
+        ],
+        "object_name": "http.network.protocol.version",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.request.method": {
+        "category": "http",
+        "component": "http",
+        "caption": "Request Method",
+        "description": "The HTTP request method.",
+        "examples": [
+          "GET",
+          "POST"
+        ],
+        "object_name": "http.request.method",
+        "object_type": "keyword"
+      }
+    },
+    {
+    {
+      "http.response.status_code": {
+        "category": "http",
+        "component": "http",
+        "caption": "HTTP Response Status Code",
+        "description": "HTTP response status code. Conditionally Required: If and only if one was received/sent.",
+        "examples": [
+          200
+        ],
+        "object_name": "http.response.status_code",
+        "object_type": "integer"
+      }
+    },
+    {
+      "server.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Address",
+        "description": "Name of the local HTTP server that received the request.",
+        "examples": [
+          "example.com"
+        ],
+        "object_name": "server.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Port",
+        "description": "Port of the local HTTP server that received the request.",
+        "examples": [
+          "80",
+          "8080",
+          "443"
+        ],
+        "object_name": "server.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "server.socket.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Address",
+        "description": "Local socket address. Useful in case of a multi-IP host.",
+        "examples": [
+          "10.5.3.2"
+        ],
+        "object_name": "server.socket.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.socket.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Port",
+        "description": "Local socket port. Useful in case of a multi-port host.",
+        "examples": [
+          "16456"
+        ],
+        "object_name": "server.socket.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "url.scheme": {
+        "category": "services",
+        "component": "http",
+        "caption": "URL Scheme",
+        "description": "The URI scheme component identifying the used protocol.",
+        "examples": [
+          "http",
+          "https"
+        ],
+        "object_name": "url.scheme",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/metrics/http.mapping
+++ b/schema/observability/metrics/http.mapping
@@ -1,0 +1,84 @@
+{
+  "template": {
+    "mappings": {
+      "_meta": {
+        "version": "1.0.0",
+        "catalog": "observability",
+        "type": "metrics",
+        "component": "http"
+      },
+      "properties": {
+        "http": {
+          "properties": {
+            "network.protocol.name": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "network.protocol.version": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "request": {
+              "type": "object",
+              "properties": {
+                "method": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "response": {
+              "type": "object",
+              "properties": {
+                "status_code": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "client": {
+              "type": "object",
+              "properties": {
+                "server.socket.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "server.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "server.port": {
+                  "type": "long"
+                }
+              }
+            },
+            "server": {
+              "type": "object",
+              "properties": {
+                "route": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "port": {
+                  "type": "long"
+                },
+                "socket.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "url.schema": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/observability/metrics/http.schema
+++ b/schema/observability/metrics/http.schema
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "http": {
+      "type": "object",
+      "properties": {
+        "network.protocol.name": {
+          "type": "string"
+        },
+        "network.protocol.version": {
+          "type": "string"
+        },
+        "request": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string"
+            }
+          },
+          "required": ["method"]
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "status_code": {
+              "type": "string"
+            }
+          },
+          "required": ["status_code"]
+        },
+        "client": {
+          "type": "object",
+          "properties": {
+            "server.socket.address": {
+              "type": "string"
+            },
+            "server.address": {
+              "type": "string"
+            },
+            "server.port": {
+              "type": "integer"
+            }
+          },
+          "required": ["server.socket.address", "server.address", "server.port"]
+        },
+        "server": {
+          "type": "object",
+          "properties": {
+            "route": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "socket.address": {
+              "type": "string"
+            },
+            "url.schema": {
+              "type": "string"
+            }
+          },
+          "required": ["route", "address", "port", "socket.address", "url.schema"]
+        }
+      },
+      "required": ["network.protocol.name", "network.protocol.version", "request", "response", "client", "server"]
+    }
+  },
+  "required": ["http"]
+}

--- a/schema/observability/traces/http.dictionary
+++ b/schema/observability/traces/http.dictionary
@@ -1,0 +1,413 @@
+{
+  "catalog": "observability",
+  "version": "1.0",
+  "attributes": [
+    {
+      "http.user_agent.original": {
+        "category": "http",
+        "component": "http",
+        "caption": "User Agent Original",
+        "description": "The original user agent string.",
+        "examples": [
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64)",
+          "PostmanRuntime/7.26.8"
+        ],
+        "object_name": "http.user_agent.original",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.network.transport": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Transport",
+        "description": "The network transport protocol.",
+        "examples": [
+          "tcp",
+          "udp"
+        ],
+        "object_name": "http.network.transport",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.network.type": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Type",
+        "description": "The type of network.",
+        "examples": [
+          "ipv4",
+          "ipv6"
+        ],
+        "object_name": "http.network.type",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.network.protocol.name": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Protocol Name",
+        "description": "The name of network protocol.",
+        "examples": [
+          "http",
+          "https"
+        ],
+        "object_name": "http.network.protocol.name",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.network.protocol.version": {
+        "category": "http",
+        "component": "http",
+        "caption": "Network Protocol Version",
+        "description": "The version of network protocol.",
+        "examples": [
+          "1.1",
+          "2"
+        ],
+        "object_name": "http.network.protocol.version",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.request.method": {
+        "category": "http",
+        "component": "http",
+        "caption": "Request Method",
+        "description": "The HTTP request method.",
+        "examples": [
+          "GET",
+          "POST"
+        ],
+        "object_name": "http.request.method",
+        "object_type": "keyword"
+      }
+    },
+    {
+    {
+      "http.response.status_code": {
+        "category": "http",
+        "component": "http",
+        "caption": "HTTP Response Status Code",
+        "description": "HTTP response status code. Conditionally Required: If and only if one was received/sent.",
+        "examples": [
+          200
+        ],
+        "object_name": "http.response.status_code",
+        "object_type": "integer"
+      }
+    },
+    {
+      "http.request.body.size": {
+        "category": "http",
+        "component": "http",
+        "caption": "Request Body Size",
+        "description": "The size of the request payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Recommended",
+        "examples": [
+          3495
+        ],
+        "object_name": "http.request.body.size",
+        "object_type": "integer"
+      }
+    },
+    {
+      "http.response.body.size": {
+        "category": "http",
+        "component": "http",
+        "caption": "Response Body Size",
+        "description": "The size of the response payload body in bytes. This is the number of bytes transferred excluding headers and is often, but not always, present as the Content-Length header. For requests using transport encoding, this should be the compressed size. Recommended",
+        "examples": [
+          3495
+        ],
+        "object_name": "http.response.body.size",
+        "object_type": "integer"
+      }
+    },
+    {
+      "http.request.header.<key>": {
+        "category": "http",
+        "component": "request",
+        "caption": "HTTP Request Header",
+        "description": "HTTP request headers, <key> being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values.",
+        "examples": [
+          "http.request.header.content_type=['application/json']",
+          "http.request.header.x_forwarded_for=['1.2.3.4', '1.2.3.5']"
+        ],
+        "object_name": "http.request.header.<key>",
+        "object_type": "string[]"
+      }
+    },
+    {
+      "http.response.header.<key>": {
+        "category": "http",
+        "component": "response",
+        "caption": "HTTP Response Header",
+        "description": "HTTP response headers, <key> being the normalized HTTP Header name (lowercase, with - characters replaced by _), the value being the header values.",
+        "examples": [
+          "http.response.header.content_type=['application/json']",
+          "http.response.header.my_custom_header=['abc', 'def']"
+        ],
+        "object_name": "http.response.header.<key>",
+        "object_type": "string[]"
+      }
+    },
+    {
+      "http.resend_count": {
+        "category": "services",
+        "component": "http",
+        "caption": "HTTP Resend Count",
+        "description": "The ordinal number of request resending attempt (for any reason, including redirects).",
+        "examples": [
+          "3"
+        ],
+        "object_name": "http.resend_count",
+        "object_type": "long"
+      }
+    },
+    {
+      "server.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Address",
+        "description": "Host identifier of the 'URI origin' HTTP request is sent to.",
+        "examples": [
+          "example.com"
+        ],
+        "object_name": "server.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Port",
+        "description": "Port identifier of the 'URI origin' HTTP request is sent to.",
+        "examples": [
+          "80",
+          "8080",
+          "443"
+        ],
+        "object_name": "server.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "server.socket.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Address",
+        "description": "Physical server IP address or Unix socket address.",
+        "examples": [
+          "10.5.3.2"
+        ],
+        "object_name": "server.socket.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.socket.domain": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Domain",
+        "description": "The domain name of an immediate peer.",
+        "examples": [
+          "proxy.example.com"
+        ],
+        "object_name": "server.socket.domain",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.socket.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Port",
+        "description": "Physical server port.",
+        "examples": [
+          "16456"
+        ],
+        "object_name": "server.socket.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "url.full": {
+        "category": "services",
+        "component": "http",
+        "caption": "Full URL",
+        "description": "Absolute URL describing a network resource according to RFC3986.",
+        "examples": [
+          "https://www.foo.bar/search?q=OpenTelemetry#SemConv",
+          "//localhost"
+        ],
+        "object_name": "url.full",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "http.route": {
+        "category": "services",
+        "component": "http",
+        "caption": "HTTP Route",
+        "description": "The matched route (path template in the format used by the respective server framework).",
+        "examples": [
+          "/users/:userID?",
+          "{controller}/{action}/{id?}"
+        ],
+        "object_name": "http.route",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "client.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Client Address",
+        "description": "Client address - unix domain socket name, IPv4 or IPv6 address.",
+        "examples": [
+          "83.164.160.102"
+        ],
+        "object_name": "client.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "client.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Client Port",
+        "description": "The port of the original client behind all proxies, if known (e.g. from Forwarded or a similar header). Otherwise, the immediate client peer port.",
+        "examples": [
+          "65123"
+        ],
+        "object_name": "client.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "client.socket.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Client Socket Address",
+        "description": "Immediate client peer address - unix domain socket name, IPv4 or IPv6 address.",
+        "examples": [
+          "/tmp/my.sock",
+          "127.0.0.1"
+        ],
+        "object_name": "client.socket.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "client.socket.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Client Socket Port",
+        "description": "Immediate client peer port number",
+        "examples": [
+          "35555"
+        ],
+        "object_name": "client.socket.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "server.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Address",
+        "description": "Name of the local HTTP server that received the request.",
+        "examples": [
+          "example.com"
+        ],
+        "object_name": "server.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Port",
+        "description": "Port of the local HTTP server that received the request.",
+        "examples": [
+          "80",
+          "8080",
+          "443"
+        ],
+        "object_name": "server.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "server.socket.address": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Address",
+        "description": "Local socket address. Useful in case of a multi-IP host.",
+        "examples": [
+          "10.5.3.2"
+        ],
+        "object_name": "server.socket.address",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "server.socket.port": {
+        "category": "services",
+        "component": "http",
+        "caption": "Server Socket Port",
+        "description": "Local socket port. Useful in case of a multi-port host.",
+        "examples": [
+          "16456"
+        ],
+        "object_name": "server.socket.port",
+        "object_type": "long"
+      }
+    },
+    {
+      "url.path": {
+        "category": "services",
+        "component": "http",
+        "caption": "URL Path",
+        "description": "The URI path component.",
+        "examples": [
+          "/search"
+        ],
+        "object_name": "url.path",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "url.query": {
+        "category": "services",
+        "component": "http",
+        "caption": "URL Query",
+        "description": "The URI query component.",
+        "examples": [
+          "q=OpenTelemetry"
+        ],
+        "object_name": "url.query",
+        "object_type": "keyword"
+      }
+    },
+    {
+      "url.scheme": {
+        "category": "services",
+        "component": "http",
+        "caption": "URL Scheme",
+        "description": "The URI scheme component identifying the used protocol.",
+        "examples": [
+          "http",
+          "https"
+        ],
+        "object_name": "url.scheme",
+        "object_type": "keyword"
+      }
+    }
+  ]
+}

--- a/schema/observability/traces/http.mapping
+++ b/schema/observability/traces/http.mapping
@@ -1,0 +1,151 @@
+{
+  "template": {
+    "mappings": {
+      "_meta": {
+        "version": "1.0.0",
+        "catalog": "observability",
+        "type": "traces",
+        "component": "http"
+      },
+      "properties": {
+        "http": {
+          "properties": {
+            "user_agent.original": {
+              "type": "keyword",
+              "ignore_above": 1024
+            },
+            "network.transport": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "network.type": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "network.protocol.name": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "network.protocol.version": {
+              "type": "keyword",
+              "ignore_above": 256
+            },
+            "request": {
+              "type": "object",
+              "properties": {
+                "method": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "method_original": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "body.size": {
+                  "type": "long"
+                },
+                "header" : {
+                  "type": "object"
+                }
+              }
+            },
+            "response": {
+              "type": "object",
+              "properties": {
+                "status_code": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                },
+                "body.size": {
+                  "type": "long"
+                },
+                "header" : {
+                  "type": "object"
+                }
+              }
+            },
+            "client": {
+              "type": "object",
+              "properties": {
+                "server.socket.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "server.socket.domain": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "server.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "server.port": {
+                  "type": "long"
+                },
+                "server.socket.port": {
+                  "type": "long"
+                },
+                "resend_count": {
+                  "type": "long"
+                },
+                "url.full": {
+                  "type": "keyword",
+                  "ignore_above": 2048
+                }
+              }
+            },
+            "server": {
+              "type": "object",
+              "properties": {
+                "route": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "port": {
+                  "type": "long"
+                },
+                "socket.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "socket.port": {
+                  "type": "long"
+                },
+                "client.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "client.port": {
+                  "type": "long"
+                },
+                "client.socket.address": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "client.socket.port": {
+                  "type": "long"
+                },
+                "url.path": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "url.query": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "url.schema": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schema/observability/traces/http.schema
+++ b/schema/observability/traces/http.schema
@@ -1,0 +1,196 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "http": {
+      "type": "object",
+      "properties": {
+        "user_agent": {
+          "type": "object",
+          "properties": {
+            "original": {
+              "type": "string"
+            }
+          },
+          "required": ["original"]
+        },
+        "network": {
+          "type": "object",
+          "properties": {
+            "transport": {
+              "type": "string"
+            },
+            "type": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "version": {
+                  "type": "string"
+                }
+              },
+              "required": ["name", "version"]
+            }
+          },
+          "required": ["transport", "type", "protocol"]
+        },
+        "request": {
+          "type": "object",
+          "properties": {
+            "method": {
+              "type": "string"
+            },
+            "method_original": {
+              "type": "string"
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "size": {
+                  "type": "integer"
+                }
+              },
+              "required": ["size"]
+            }
+          },
+          "required": ["method", "method_original", "body"]
+        },
+        "response": {
+          "type": "object",
+          "properties": {
+            "status_code": {
+              "type": "string"
+            },
+            "body": {
+              "type": "object",
+              "properties": {
+                "size": {
+                  "type": "integer"
+                }
+              },
+              "required": ["size"]
+            }
+          },
+          "required": ["status_code", "body"]
+        },
+        "client": {
+          "type": "object",
+          "properties": {
+            "server": {
+              "type": "object",
+              "properties": {
+                "socket": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "domain": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["address", "domain", "port"]
+                },
+                "address": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer"
+                }
+              },
+              "required": ["socket", "address", "port"]
+            },
+            "resend_count": {
+              "type": "integer"
+            },
+            "url": {
+              "type": "object",
+              "properties": {
+                "full": {
+                  "type": "string"
+                }
+              },
+              "required": ["full"]
+            }
+          },
+          "required": ["server", "resend_count", "url"]
+        },
+        "server": {
+          "type": "object",
+          "properties": {
+            "route": {
+              "type": "string"
+            },
+            "address": {
+              "type": "string"
+            },
+            "port": {
+              "type": "integer"
+            },
+            "socket": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "type": "string```
+                },
+                "port": {
+                  "type": "integer"
+                }
+              },
+              "required": ["address", "port"]
+            },
+            "client": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "type": "string"
+                },
+                "port": {
+                  "type": "integer"
+                },
+                "socket": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "port": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["address", "port"]
+                }
+              },
+              "required": ["address", "port", "socket"]
+            },
+            "url": {
+              "type": "object",
+              "properties": {
+                "path": {
+                  "type": "string"
+                },
+                "query": {
+                  "type": "string"
+                },
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "required": ["path", "query", "schema"]
+            }
+          },
+          "required": ["route", "address", "port", "socket", "client", "url"]
+        }
+      },
+      "required": ["user_agent", "network", "request", "response", "client", "server"]
+    }
+  },
+  "required": ["http"]
+}


### PR DESCRIPTION
### Description
Adding HTTP based semantic conventions

### Issues Resolved
- https://github.com/opensearch-project/opensearch-catalog/issues/25
- https://github.com/opensearch-project/opensearch-catalog/issues/24

See
* https://github.com/open-telemetry/semantic-conventions/tree/main/docs/http
---
 * [Trace](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/trace-general.md): Semantic Conventions for traces and spans.
* [Metrics](https://github.com/open-telemetry/semantic-conventions/blob/main/docs/general/metrics-general.md): Semantic Conventions for metrics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
