### PR TITLE
update CODEOWNERS with new maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @bowenlan-amzn @khushbr @praveensameneni @ananzh @seanneumann @AMoo-Miki
+*   @bowenlan-amzn @khushbr @praveensameneni @ananzh @seanneumann @AMoo-Miki @YANG-DB


### PR DESCRIPTION
### Description
update CODEOWNERS with new maintainer

### Issues Resolved
Updating the codeowners github's account name (according to the [next doc](https://github.com/opensearch-project/opensearch-catalog/blob/main/MAINTAINERS.md))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
