### PR TITLE
add href and linkage support navigation from the service map into a t…

### DIFF
--- a/visualizations/observability/service-map/README.md
+++ b/visualizations/observability/service-map/README.md
@@ -8,7 +8,7 @@ The Service Map Widget for OpenSearch Dashboards uses Vega for complex visualiza
 This widget graphically presents service map interactions, ingested via [data-prepper service_map pipelines](https://opensearch.org/docs/2.4/data-prepper/pipelines/configuration/processors/service-map-stateful/), aiding in performance monitoring and troubleshooting.
 See additional [instruction](../../vega-visualizations.md) on how to use and build [vega based visualization](https://opensearch.org/docs/latest/dashboards/visualize/viz-index/#vega) in the dashboards.
 
-![Service Map Visualization](service-map.png)
+![Service Map Visualization](static/service-map.png)
 
 ## Vega Integration
 Vega's integration allows for customized, interactive graph creation, enabling detailed visual analysis of service maps.
@@ -88,6 +88,19 @@ Aggregates connections between services and their destinations.
     }
   }
   ```
+## Navigation
+The Service graph map offers a new navigation capability from the service graph into a dedicated dashboard including the 
+selected serviceName as part of the target dashboard's filter.
+
+This feature is using the `"href": {"signal": "datum.link"}` vega url navigation capability.
+
+Here is how the `link` field is structured:
+
+ - target URL: `http://localhost:5601/app/dashboards#/view/single-service-correlated-dashboard-1_0_0_ID`
+ - target dashboard (navigating using dashboard ID) : `single-service-correlated-dashboard-1_0_0_ID`
+ - filter in the target dashboard: `_a=(filters:!(....,query:(match_phrase:(serviceName:' + datum.name + ')))),...'`
+   - here the `datum.name` is the parameterized user mouse click selection
+
 
 ## Prerequisites
 Required indices: `otel-v1-apm-service-map`, `otel-v1-apm-span-*`.

--- a/visualizations/observability/service-map/dql-services-graph-widget.json
+++ b/visualizations/observability/service-map/dql-services-graph-widget.json
@@ -266,6 +266,11 @@
           "type": "formula",
           "expr": "datum.key",
           "as": "group"
+        },
+        {
+          "type": "formula",
+          "expr": "'http://localhost:5601/app/dashboards#/view/single-service-correlated-dashboard-1_0_0_ID?_a=(filters:!((%27$state%27:(store:appState),meta:(alias:!n,disabled:!f,key:serviceName,negate:!f,params:(query:' + datum.serviceName + '),type:phrase),query:(match_phrase:(serviceName:' + datum.name + ')))),fullScreenMode:!f,options:(hidePanelTitles:!f,useMargins:!t),query:(language:kuery,query:%27%27),timeRestore:!f,title:single-service-correlated-dashboard,viewMode:view)'",
+          "as": "link"
         }
       ]
     },
@@ -532,6 +537,7 @@
       "encode": {
         "update": {
           "opacity": {"value": 1},
+          "href": {"signal": "datum.link"},
           "fill": {
             "signal": "nodeHover.id===datum.index || indexof(nodeHover.connections, datum.name)>-1 ?scale('color', datum.group):merge(hsl(scale('color', datum.group)), {l:0.64})"
           },


### PR DESCRIPTION
### Description
#### Navigation
The Service graph map offers a new navigation capability from the service graph into a dedicated dashboard including the 
selected serviceName as part of the target dashboard's filter.

This feature is using the `"href": {"signal": "datum.link"}` vega url navigation capability.

Here is how the `link` field is structured:

 - target URL: `http://localhost:5601/app/dashboards#/view/single-service-correlated-dashboard-1_0_0_ID`
 - target dashboard (navigating using dashboard ID) : `single-service-correlated-dashboard-1_0_0_ID`
 - filter in the target dashboard: `_a=(filters:!(....,query:(match_phrase:(serviceName:' + datum.name + ')))),...'`
   - here the `datum.name` is the parameterized user mouse click selection


https://github.com/opensearch-project/opensearch-catalog/assets/48943349/2e62f25b-b995-48cd-a948-5ad143f22a52


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
