### PR TITLE
Update maintainers: add self and move Sean

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -10,12 +10,13 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Khushboo Rajput  | [khushbr](https://github.com/khushbr)                 | Amazon      |
 | Praveen Sameneni | [praveensameneni](https://github.com/praveensameneni) | Amazon      |
 | Anan Zhuang      | [ananzh](https://github.com/ananzh)                   | Amazon      |
-| Sean Neumann     | [seanneumann](https://github.com/seanneumann)         | Amazon      |
 | Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)             | Amazon      |
 | Lior Perry       | [YANG-DB](https://github.com/YANG-DB/)                | Amazon      |
+| Simeon Widdis    | [Swiddis](https://github.com/Swiddis)                 | Amazon      |
 
 ## Emeritus
 
 | Maintainer       | GitHub ID                                             | Affiliation |
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Drew Baugher     | [dbbaughe](https://github.com/dbbaughe)               | Amazon      |
+| Sean Neumann     | [seanneumann](https://github.com/seanneumann)         | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -19,4 +19,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer       | GitHub ID                                             | Affiliation |
 | ---------------- | ----------------------------------------------------- | ----------- |
 | Drew Baugher     | [dbbaughe](https://github.com/dbbaughe)               | Amazon      |
-| Sean Neumann     | [seanneumann](https://github.com/seanneumann)         | Amazon      |
+| Sean Neumann     | [seanneumann](https://github.com/seanneumann)         | Contributor      |


### PR DESCRIPTION
### Description
Following my request to be added as a maintainer per the [nomination process](https://github.com/opensearch-project/.github/blob/main/RESPONSIBILITIES.md#becoming-a-maintainer), this PR adds myself to the maintainers list. Also, the ex-maintainer Sean Neumann has been moved to emeritus.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
