### PR TITLE
[BUG] fix vpc `protocol` field to match vpc original declaration

### DIFF
--- a/integrations/observability/amazon_vpc_flow/amazon_vpc_flow-1.0.0.json
+++ b/integrations/observability/amazon_vpc_flow/amazon_vpc_flow-1.0.0.json
@@ -1,6 +1,6 @@
 {
   "name": "amazon_vpc_flow",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "displayName": "Amazon VPC",
   "description": "Monitor IP traffic with VPC Flow Logs.",
   "license": "Apache-2.0",

--- a/integrations/observability/amazon_vpc_flow/assets/create_table_vpc_schema-1.0.0.sql
+++ b/integrations/observability/amazon_vpc_flow/assets/create_table_vpc_schema-1.0.0.sql
@@ -6,7 +6,7 @@ CREATE EXTERNAL TABLE IF NOT EXISTS {table_name} (
     dstaddr string,
     srcport int,
     dstport int,
-    protocol bigint,
+    protocol int,
     packets bigint,
     bytes bigint,
     start bigint,


### PR DESCRIPTION
### Description
Fix vpc `protocol` field to match vpc original declaration:
 -  Protocol column is INT32 in VPC doc but Athena create table uses BIGINT which I think our integration refers to VPC doc: https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-log-records
 -  Athena doc: https://docs.aws.amazon.com/athena/latest/ug/vpc-flow-logs.html
 -  Integration code: https://github.com/opensearch-project/opensearch-catalog/blob/main/integrations/observability/amazon_vpc_flow/assets/create_table_vpc_schema-1.0.0.sql#L9


### Issues Resolved
#167

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
